### PR TITLE
DecodeFrames and support for multiple frames in xhr payloads

### DIFF
--- a/sockjs/jsonp-send.go
+++ b/sockjs/jsonp-send.go
@@ -43,7 +43,7 @@ func (ctx *context) JsonpSendHandler(rw http.ResponseWriter, req *http.Request) 
 
 		rw.WriteHeader(http.StatusOK)
 		rw.Write([]byte("ok"))
-		go func() { conn.input_channel <- data }() // does not need to be extra routine?
+		conn.input_channel <- data
 	} else {
 		rw.WriteHeader(http.StatusNotFound)
 	}

--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -23,14 +23,16 @@ type Config struct {
 	HeartbeatDelay  time.Duration
 	DisconnectDelay time.Duration
 	CookieNeeded    bool
+	DecodeFrames    bool
 }
 
 // Default Configuration with 128kB response limit
 var DefaultConfig = Config{
-	SockjsUrl:       "http://cdn.sockjs.org/sockjs-0.3.2.min.js", // default JS
+	SockjsUrl:       "http://cdn.sockjs.org/sockjs-0.3.4.min.js", // default JS
 	Websocket:       true,                                        // enabled websocket
 	ResponseLimit:   128 * 1024,                                  // 128kB
 	HeartbeatDelay:  time.Duration(25 * time.Second),             // 25s
 	DisconnectDelay: time.Duration(5 * time.Second),              // 5s
 	CookieNeeded:    false,
+	DecodeFrames:    false,
 }


### PR DESCRIPTION
Bumped SockJS client URL version to 0.3.4.
Removed goroutines for sending to channels.
Added a DecodeFrames config option which removes the SockJS JSON formatting when calling ReadMessage.
Added handling of receiving multiple frames in one payload with xhr. They will now be transparently sent to the input channel as separate messages..
