### PR TITLE
SockJS should work cross-origin

### DIFF
--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -17,11 +17,6 @@ var WebSocketReadBufSize = 4096
 var WebSocketWriteBufSize = 4096
 
 func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
-	origin := req.Header.Get("Origin")
-	if origin != "http://"+req.Host && origin != "https://"+req.Host {
-		http.Error(rw, "Origin not allowed", 403)
-		return
-	}
 	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)


### PR DESCRIPTION
Ideally, a SockJS implementation would be configurable with regard to cross-origin requests.  But the default, IMO, should be to allow them.  Having it hardcoded to disallow cross-origin requests seems counter to one of main features of SockJS, which indeed is to be cross-origin.

This pull request aims to remedy that, by removing the special case altogether.  I open it for discussion.
