### PR TITLE
Fix prefix regexp

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -27,7 +27,11 @@ func NewHandler(prefix string, opts Options, handleFunc func(Session)) http.Hand
 }
 
 func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler {
-	prefix = "^" + regexp.QuoteMeta(path.Clean("/"+prefix))
+	prefix = path.Clean("/" + prefix)
+	if prefix == "/" {
+		prefix = ""
+	}
+	prefix = "^" + regexp.QuoteMeta(cleanPrefix)
 
 	h := &handler{
 		prefix:      prefix,


### PR DESCRIPTION
First of all, thanks for sockjs-go!
I have started using it and it looks pretty good!

I was taking a look at the way prefix is handled internally and thought:
- prefixes are interpreted as regexps, but it is not obvious to the user: they should be escaped
- force the prefix regexp to start with `^` so that `/prefix/` matches but `/not_prefix/prefix/` doesn't.
- remove trailing `/` from prefix by using path.Clean so `prefix+"/something"` avoids double slashes.
- removed (apparently) unecessary `?` from `/info?$` regexps
- appended `$` to some regexps (apparently) missing it

Please let me know if I incorrectly interpreted any of the points above.

PS: let me know if you would prefer removing trailing `/` characters only, and avoid using path.Clean (which does more than just that like taking care of `/../` etc.).
