### PR TITLE
Fix race where sending messages after large messages may fail

### DIFF
--- a/sockjs/httpreceiver.go
+++ b/sockjs/httpreceiver.go
@@ -97,3 +97,6 @@ func (recv *httpReceiver) close() {
 		close(recv.doneCh)
 	}
 }
+func (recv *httpReceiver) canSend() bool {
+	return recv.state != stateHTTPReceiverClosed
+}

--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -61,6 +61,7 @@ type receiver interface {
 	sendFrame(string)
 	// close closes the receiver in a "done" way (idempotent)
 	close()
+	canSend() bool
 	// done notification channel gets closed whenever receiver ends
 	doneNotify() <-chan struct{}
 	// interrupted channel gets closed whenever receiver is interrupted (i.e. http connection drops,...)
@@ -92,7 +93,7 @@ func (s *session) sendMessage(msg string) error {
 		return ErrSessionNotOpen
 	}
 	s.sendBuffer = append(s.sendBuffer, msg)
-	if s.recv != nil {
+	if s.recv != nil && s.recv.canSend() {
 		s.recv.sendBulk(s.sendBuffer...)
 		s.sendBuffer = nil
 	}

--- a/sockjs/session_test.go
+++ b/sockjs/session_test.go
@@ -307,6 +307,14 @@ type testReceiver struct {
 func (t *testReceiver) doneNotify() <-chan struct{}        { return t.doneCh }
 func (t *testReceiver) interruptedNotify() <-chan struct{} { return t.interruptCh }
 func (t *testReceiver) close()                             { close(t.doneCh) }
+func (t *testReceiver) canSend() bool {
+	select {
+	case <-t.doneCh:
+		return false // already closed
+	default:
+		return true
+	}
+}
 func (t *testReceiver) sendBulk(messages ...string) {
 	for _, m := range messages {
 		t.sendFrame(m)

--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -85,5 +85,13 @@ func (w *wsReceiver) close() {
 		close(w.closeCh)
 	}
 }
+func (w *wsReceiver) canSend() bool {
+	select {
+	case <-w.closeCh: // already closed
+		return false
+	default:
+		return true
+	}
+}
 func (w *wsReceiver) doneNotify() <-chan struct{}        { return w.closeCh }
 func (w *wsReceiver) interruptedNotify() <-chan struct{} { return nil }


### PR DESCRIPTION
With large messages on XHR-streaming and XHR-poll (possibly others) the stateHTTPReceiverClosed state may be set on httpReceiver, which causes future calls to sendBulk to be a no-op until another receiver attaches. This is usually not a problem because a goroutine in session.attachReceiver calls detachReceiver soon after, and detach causes the session's recv field to be nulled out. However, if msgs are sent between the time when stateHTTPReceiverClosed is called and detachReceiver occurs, then those messages will be silently ignored.

I could think of several approaches to fixing the problem:

1. Add a `receiver.canSend()` method that will tell the would-be sender that the receiver is not usable at this time. This is the simplest fix but the downside is that everywhere `s.recv != nil` is checked, now `s.recv.canSend()` must also be at least considered.
2. Have `receiver.sendBulk()` return an indication of whether sending succeeded, and if not, whether the messages should be buffered for later. (This seems like it would be a good idea even if this issue did not exist)
3. Have `receiver.sendBulk()` take a reference to the buffer, and be responsible for taking messages off it if it successfully sends.
4. Make the cleanup of session (`detachReceiver`) happen synchronously with closing.

This PR implements approach 1 as it seemed like the least risky approach.