### PR TITLE
Added SetHeartbeatHandler to Session interface

### DIFF
--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -8,6 +8,8 @@ type Session interface {
 	ID() string
 	// Request returns the first http request
 	Request() *http.Request
+	// SetHeartbeatHandler is called after a heartbeat is sent.
+	SetHeartbeatHandler(handler func())
 	// Recv reads one text frame from session
 	Recv() (string, error)
 	// Send sends one text frame to session


### PR DESCRIPTION
I need this functionality in order to avoid duplicating the logic of handling heartbeats in my own code.
I could do it, but there would be a waste of timers going around.

I have a doubt about the heartbeat function.
I did change it so that a handler can call say session.Send or even session.SetHeartbeatHandler(nil) anything else even if that requires locking. If i call it inside the mutex, that won't be possible.
The most obvious "drawback" of this, is that if the timer is "too fast" (like in the order of a few nanoseconds, which shouldn't happen in principle) the handler may be called concurrently, or if the handler itself does something like session.SetHeartbeatHandler(newHandler) an old handler could be called, because it is called outside the mutex. So, some care should be taken regarding that.

What do you think of this?