### PR TITLE
handler: improve memory allocation and speed

### DIFF
--- a/sockjs/benchmarks_test.go
+++ b/sockjs/benchmarks_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -79,4 +80,15 @@ func BenchmarkMessages(b *testing.B) {
 	}
 	wg.Wait()
 	server.Close()
+}
+
+func BenchmarkHandler_ParseSessionID(b *testing.B) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.parseSessionID(url)
+	}
 }


### PR DESCRIPTION
I was profiling the memory allocation for our kite library
https://github.com/koding/kite. It uses the sockjs server extensively, and I saw that
for every single request we would compile the regexp object, even if it's the same.

We know add a hot cache, evaluated lazily for a prefix. The results can be seen
below and it dramatically changes the speed and memory allocation of the handler.

Change between the old and new can be seen below:

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkHandler_ParseSessionID     19985         4465          -77.66%

benchmark                           old allocs     new allocs     delta
BenchmarkHandler_ParseSessionID     61             2              -96.72%

benchmark                           old bytes     new bytes     delta
BenchmarkHandler_ParseSessionID     6560          96            -98.54%
```