### PR TITLE
Add client IP export to session

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -117,7 +117,7 @@ func (h *handler) sessionByRequest(req *http.Request) (*session, error) {
 	}
 	sess, exists := h.sessions[sessionID]
 	if !exists {
-		sess = newSession(sessionID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+		sess = newSession(sessionID, h.options.DisconnectDelay, h.options.HeartbeatDelay, req.RemoteAddr)
 		h.sessions[sessionID] = sess
 		if h.handlerFunc != nil {
 			go h.handlerFunc(sess)

--- a/sockjs/jsonp_test.go
+++ b/sockjs/jsonp_test.go
@@ -69,7 +69,7 @@ func TestHandler_jsonpSendNoSession(t *testing.T) {
 
 func TestHandler_jsonpSend(t *testing.T) {
 	h := newTestHandler()
-	sess := newSession("session", time.Second, time.Second)
+	sess := newSession("session", time.Second, time.Second, "::1")
 	h.sessions["session"] = sess
 
 	rw := httptest.NewRecorder()

--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -31,6 +31,7 @@ var (
 type session struct {
 	sync.Mutex
 	id    string
+	ip    string
 	state sessionState
 	// protocol dependent receiver (xhr, eventsource, ...)
 	recv receiver
@@ -69,10 +70,11 @@ type receiver interface {
 }
 
 // Session is a central component that handles receiving and sending frames. It maintains internal state
-func newSession(sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration) *session {
+func newSession(sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration, ip string) *session {
 	r, w := io.Pipe()
 	s := &session{
 		id:                     sessionID,
+		ip:                     ip,
 		msgReader:              r,
 		msgWriter:              w,
 		msgEncoder:             gob.NewEncoder(w),
@@ -215,3 +217,5 @@ func (s *session) Send(msg string) error {
 }
 
 func (s *session) ID() string { return s.id }
+
+func (s *session) IP() string { return s.ip }

--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -4,6 +4,8 @@ package sockjs
 type Session interface {
 	// Id returns a session id
 	ID() string
+	// IP returns the remote address of the connected client
+	IP() string
 	// Recv reads one text frame from session
 	Recv() (string, error)
 	// Send sends one text frame to session

--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -26,7 +26,7 @@ func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	sessID, _ := h.parseSessionID(req.URL)
-	sess := newSession(sessID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+	sess := newSession(sessID, h.options.DisconnectDelay, h.options.HeartbeatDelay, req.RequestURI)
 	if h.handlerFunc != nil {
 		go h.handlerFunc(sess)
 	}

--- a/sockjs/xhr_test.go
+++ b/sockjs/xhr_test.go
@@ -46,7 +46,7 @@ func TestHandler_XhrSendWrongUrlPath(t *testing.T) {
 
 func TestHandler_XhrSendToExistingSession(t *testing.T) {
 	h := newTestHandler()
-	sess := newSession("session", time.Second, time.Second)
+	sess := newSession("session", time.Second, time.Second, "::1")
 	h.sessions["session"] = sess
 
 	rec := httptest.NewRecorder()
@@ -126,7 +126,7 @@ func TestHandler_XhrPollConnectionInterrupted(t *testing.T) {
 func TestHandler_XhrPollAnotherConnectionExists(t *testing.T) {
 	h := newTestHandler()
 	// turn of timeoutes and heartbeats
-	sess := newSession("session", time.Hour, time.Hour)
+	sess := newSession("session", time.Hour, time.Hour, "::1")
 	h.sessions["session"] = sess
 	sess.attachReceiver(newTestReceiver())
 	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)


### PR DESCRIPTION
It is often required to know the IP address of your connected client. Other SockJS server libraries, like node-sockjs, for example, expose this on the session type. 

Note: The travis build is failing because the `code.google.com/p/go.net/websocket` import in `./testserver` seems to redirect to Github now. `./sockjs` passes all tests, including the added one for IP exporting. 