### PR TITLE
Updates the CDN URL

### DIFF
--- a/examples/webchat/web/index.html
+++ b/examples/webchat/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script type="text/javascript" src="http://cdn.sockjs.org/sockjs-0.3.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js"></script>
 <script type="text/javascript" src="app.js"> </script>
 <meta charset="UTF-8">
 <title>Chat Web Example</title>

--- a/examples/webecho/web/index.html
+++ b/examples/webecho/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script type="text/javascript" src="http://cdn.sockjs.org/sockjs-0.3.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js"></script>
 <script type="text/javascript" src="app.js"> </script>
 <meta charset="UTF-8">
 <title>Echo Web Example</title>

--- a/sockjs/options.go
+++ b/sockjs/options.go
@@ -54,7 +54,7 @@ type Options struct {
 var DefaultOptions = Options{
 	Websocket:       true,
 	JSessionID:      nil,
-	SockJSURL:       "http://cdn.sockjs.org/sockjs-0.3.min.js",
+	SockJSURL:       "//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js",
 	HeartbeatDelay:  25 * time.Second,
 	DisconnectDelay: 5 * time.Second,
 	ResponseLimit:   128 * 1024,


### PR DESCRIPTION
* Fixes the [deprecated](https://github.com/sockjs/sockjs-client/issues/198) CDN URL
* Lets the browser decide if http or https is used

This makes the default values more sane and improves the examples.