### PR TITLE
Fix CloseNotify issue

### DIFF
--- a/sockjs/httpreceiver.go
+++ b/sockjs/httpreceiver.go
@@ -41,9 +41,10 @@ func newHTTPReceiver(rw http.ResponseWriter, maxResponse uint32, frameWriter fra
 	}
 	if closeNotifier, ok := rw.(http.CloseNotifier); ok {
 		// if supported check for close notifications from http.RW
+		closeNotifyCh := closeNotifier.CloseNotify()
 		go func() {
 			select {
-			case <-closeNotifier.CloseNotify():
+			case <-closeNotifyCh:
 				recv.Lock()
 				defer recv.Unlock()
 				if recv.state < stateHTTPReceiverClosed {


### PR DESCRIPTION
When built using Go 1.6, sockjs server panics when a client using xhr-polling connects.

panic: net/http: CloseNotify called after ServeHTTP finished

It looks like the implementation of CloseNotifier has changed a bit in Go 1.6, and now a call to CloseNotify shouldn't be done after ServeHTTP finishes.