### PR TITLE
Use .Set() instead of .Add() on Access-Control-Allow-Credentials

### DIFF
--- a/sockjs/web.go
+++ b/sockjs/web.go
@@ -17,7 +17,7 @@ func xhrCors(rw http.ResponseWriter, req *http.Request) {
 	if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
 		header.Add("Access-Control-Allow-Headers", allowHeaders)
 	}
-	header.Add("Access-Control-Allow-Credentials", "true")
+	header.Set("Access-Control-Allow-Credentials", "true")
 }
 
 func xhrOptions(rw http.ResponseWriter, req *http.Request) {

--- a/sockjs/web_test.go
+++ b/sockjs/web_test.go
@@ -3,6 +3,7 @@ package sockjs
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +27,21 @@ func TestXhrCors(t *testing.T) {
 	xhrCors(rec, req)
 	if rec.Header().Get("access-control-allow-headers") != "some value" {
 		t.Errorf("Incorent value for ACAH, got %s", rec.Header().Get("access-control-allow-headers"))
+	}
+
+	rec = httptest.NewRecorder()
+	xhrCors(rec, req)
+	if rec.Header().Get("access-control-allow-credentials") != "true" {
+		t.Errorf("Incorent value for ACAC, got %s", rec.Header().Get("access-control-allow-credentials"))
+	}
+
+	// verify that if Access-Control-Allow-Credentials was previously set that xhrCors() does not duplicate the value
+	rec = httptest.NewRecorder()
+	rec.Header().Set("Access-Control-Allow-Credentials", "true")
+	xhrCors(rec, req)
+	acac := rec.Header()["Access-Control-Allow-Credentials"]
+	if len(acac) != 1 || acac[0] != "true" {
+		t.Errorf("Incorent value for ACAC, got %s", strings.Join(acac, ","))
 	}
 }
 


### PR DESCRIPTION
If another middle-ware has previously set Access-Control-Allow-Credentials then the use of .Add() can result in the header being sent to client twice breaking some clients.