### PR TITLE
fix concurrent map access panic in jsonp handler

### DIFF
--- a/sockjs/jsonp.go
+++ b/sockjs/jsonp.go
@@ -56,6 +56,8 @@ func (h *handler) jsonpSend(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, "Broken JSON encoding.", http.StatusInternalServerError)
 		return
 	}
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
 	sessionID, _ := h.parseSessionID(req.URL)
 	if sess, ok := h.sessions[sessionID]; !ok {
 		http.NotFound(rw, req)

--- a/sockjs/jsonp.go
+++ b/sockjs/jsonp.go
@@ -56,9 +56,9 @@ func (h *handler) jsonpSend(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, "Broken JSON encoding.", http.StatusInternalServerError)
 		return
 	}
+	sessionID, _ := h.parseSessionID(req.URL)
 	h.sessionsMux.Lock()
 	defer h.sessionsMux.Unlock()
-	sessionID, _ := h.parseSessionID(req.URL)
 	if sess, ok := h.sessions[sessionID]; !ok {
 		http.NotFound(rw, req)
 	} else {


### PR DESCRIPTION
Hello @igm , here is a fix for jsonp transport panic:
```
fatal error: concurrent map read and map write

goroutine 1091440490 [running]:
runtime.throw(0xb65100, 0x21)
	/Users/fz/projects/go16/src/runtime/panic.go:547 +0x90 fp=0xc842c23738 sp=0xc842c23720
runtime.mapaccess2_faststr(0x90cfe0, 0xc820196360, 0xc838c8a095, 0x8, 0x0, 0x0)
	/Users/fz/projects/go16/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc842c23798 sp=0xc842c23738
github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs.(*handler).jsonpSend(0xc8201540e0, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/private/var/www/different/go/gopath/src/github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/jsonp.go:60 +0x3d1 fp=0xc842c23888 sp=0xc842c23798
github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs.(*handler).(github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs.jsonpSend)-fm(0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/private/var/www/different/go/gopath/src/github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler.go:60 +0x3e fp=0xc842c238b0 sp=0xc842c23888
github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs.(*handler).ServeHTTP(0xc8201540e0, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/private/var/www/different/go/gopath/src/github.com/centrifugal/centrifugo/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler.go:78 +0x16c fp=0xc842c239a0 sp=0xc842c238b0
github.com/centrifugal/centrifugo/libcentrifugo.(*Application).WrapShutdown.func1(0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/private/var/www/different/go/gopath/src/github.com/centrifugal/centrifugo/libcentrifugo/handlers.go:421 +0xb8 fp=0xc842c239e8 sp=0xc842c239a0
net/http.HandlerFunc.ServeHTTP(0xc8201ee0e0, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/Users/fz/projects/go16/src/net/http/server.go:1618 +0x3a fp=0xc842c23a08 sp=0xc842c239e8
github.com/centrifugal/centrifugo/libcentrifugo.(*Application).Logged.func1(0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/private/var/www/different/go/gopath/src/github.com/centrifugal/centrifugo/libcentrifugo/handlers.go:437 +0x13f fp=0xc842c23af8 sp=0xc842c23a08
net/http.HandlerFunc.ServeHTTP(0xc8201ee100, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/Users/fz/projects/go16/src/net/http/server.go:1618 +0x3a fp=0xc842c23b18 sp=0xc842c23af8
net/http.(*ServeMux).ServeHTTP(0xc820196300, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/Users/fz/projects/go16/src/net/http/server.go:1910 +0x17d fp=0xc842c23b70 sp=0xc842c23b18
net/http.serverHandler.ServeHTTP(0xc82008cb00, 0x7f4029dbd8e0, 0xc82f6c72b0, 0xc8241e5a40)
	/Users/fz/projects/go16/src/net/http/server.go:2081 +0x19e fp=0xc842c23bd0 sp=0xc842c23b70
net/http.(*conn).serve(0xc835e36480)
	/Users/fz/projects/go16/src/net/http/server.go:1472 +0xf2e fp=0xc842c23f98 sp=0xc842c23bd0
runtime.goexit()
	/Users/fz/projects/go16/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc842c23fa0 sp=0xc842c23f98
created by net/http.(*Server).Serve
	/Users/fz/projects/go16/src/net/http/server.go:2137 +0x44e
```