### PR TITLE
possibility to disable heartbeat

### DIFF
--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -129,7 +129,9 @@ func (s *session) attachReceiver(recv receiver) error {
 	s.recv.sendBulk(s.sendBuffer...)
 	s.sendBuffer = nil
 	s.timer.Stop()
-	s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	if s.heartbeatInterval > 0 {
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Hello Igor!

I am planning to move my app from server->client pings to client->server. But without possibility to disable SockJS server heartbeat I now send ping from client side, receive pong response and receive `h` frame right after that.
