### PR TITLE
add getter for session transport protocol

### DIFF
--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"path"
 	"sync"
 	"time"
 )
@@ -221,6 +222,11 @@ func (s *session) Send(msg string) error {
 }
 
 func (s *session) ID() string { return s.id }
+
+func (s *session) Protocol() string {
+	protocol := path.Base(s.req.URL.Path)
+	return protocol
+}
 
 func (s *session) GetSessionState() SessionState {
 	s.RLock()

--- a/sockjs/session_test.go
+++ b/sockjs/session_test.go
@@ -3,6 +3,7 @@ package sockjs
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
 	"sync"
@@ -300,6 +301,18 @@ func TestSession_SessionSessionId(t *testing.T) {
 	s := newTestSession()
 	if s.ID() != "sessionId" {
 		t.Errorf("Unexpected session ID, got '%s', expected '%s'", s.ID(), "sessionId")
+	}
+}
+
+func TestSession_SessionProtocol(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.URL.Path += "websocket"
+	s := newSession(req, "sessionID", 1000*time.Second, 1000*time.Second)
+	if s.Protocol() != "websocket" {
+		t.Errorf("Unexpected transport protocol, got '%s', expected '%s'", s.Protocol(), "websocket")
 	}
 }
 

--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -6,6 +6,8 @@ import "net/http"
 type Session interface {
 	// Id returns a session id
 	ID() string
+	// Protocol used for the transport
+	Protocol() string
 	// Request returns the first http request
 	Request() *http.Request
 	// Recv reads one text frame from session


### PR DESCRIPTION
This is useful when diagnosing issues with SockJS that may be related to what
kind of protocol a connection is using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/igm/sockjs-go/55)
<!-- Reviewable:end -->
