### PR TITLE
Add websocket.Upgrader option.

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -21,7 +21,7 @@ type handler struct {
 	options     Options
 	handlerFunc func(Session)
 	mappings    []*mapping
-	upgrader    *websocket.Upgrader
+	upgrader    websocket.Upgrader
 
 	sessionsMux sync.Mutex
 	sessions    map[string]*session
@@ -40,7 +40,7 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
 
-		upgrader: &websocket.Upgrader{
+		upgrader: websocket.Upgrader{
 			ReadBufferSize:  WebSocketReadBufSize,
 			WriteBufferSize: WebSocketWriteBufSize,
 			CheckOrigin: func(_ *http.Request) bool {

--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -39,19 +39,7 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		options:     opts,
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
-
-		upgrader: websocket.Upgrader{
-			ReadBufferSize:  WebSocketReadBufSize,
-			WriteBufferSize: WebSocketWriteBufSize,
-			CheckOrigin: func(_ *http.Request) bool {
-				// Allow all connections by default.
-				return true
-			},
-			Error: func(w http.ResponseWriter, r *http.Request, status int, reason error) {
-				// Don't return errors to maintain backwards compatibility.
-			},
-			EnableCompression: opts.WebsocketCompression,
-		},
+		upgrader:    opts.WebsocketUpgrader,
 	}
 
 	sessionPrefix := prefix + "/[^/.]+/[^/.]+"

--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-
-	"github.com/gorilla/websocket"
 )
 
 var (
@@ -21,7 +19,6 @@ type handler struct {
 	options     Options
 	handlerFunc func(Session)
 	mappings    []*mapping
-	upgrader    websocket.Upgrader
 
 	sessionsMux sync.Mutex
 	sessions    map[string]*session
@@ -39,7 +36,6 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		options:     opts,
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
-		upgrader:    opts.WebsocketUpgrader,
 	}
 
 	sessionPrefix := prefix + "/[^/.]+/[^/.]+"

--- a/sockjs/options.go
+++ b/sockjs/options.go
@@ -38,6 +38,9 @@ type Options struct {
 	Websocket bool
 	// This option can be used to enable raw websockets support by the server. By default raw websockets are disabled.
 	RawWebsocket bool
+	// Enable per-message compression extensions for browsers that support.
+	// See https://godoc.org/github.com/gorilla/websocket#hdr-Compression_EXPERIMENTAL for more details.
+	WebsocketCompression bool
 	// In order to keep proxies and load balancers from closing long running http requests we need to pretend that the connection is active
 	// and send a heartbeat packet once in a while. This setting controls how often this is done.
 	// By default a heartbeat packet is sent every 25 seconds.

--- a/sockjs/options.go
+++ b/sockjs/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	RawWebsocket bool
 	// Provide a custom Upgrader for Websocket connections to enable features like compression.
 	// See https://godoc.org/github.com/gorilla/websocket#Upgrader for more details.
-	WebsocketUpgrader websocket.Upgrader
+	WebsocketUpgrader *websocket.Upgrader
 	// In order to keep proxies and load balancers from closing long running http requests we need to pretend that the connection is active
 	// and send a heartbeat packet once in a while. This setting controls how often this is done.
 	// By default a heartbeat packet is sent every 25 seconds.
@@ -59,24 +59,14 @@ type Options struct {
 
 // DefaultOptions is a convenient set of options to be used for sockjs
 var DefaultOptions = Options{
-	Websocket:       true,
-	RawWebsocket:    false,
-	JSessionID:      nil,
-	SockJSURL:       "//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js",
-	HeartbeatDelay:  25 * time.Second,
-	DisconnectDelay: 5 * time.Second,
-	ResponseLimit:   128 * 1024,
-	WebsocketUpgrader: websocket.Upgrader{
-		ReadBufferSize:  WebSocketReadBufSize,
-		WriteBufferSize: WebSocketWriteBufSize,
-		CheckOrigin: func(_ *http.Request) bool {
-			// Allow all connections by default.
-			return true
-		},
-		Error: func(w http.ResponseWriter, r *http.Request, status int, reason error) {
-			// Don't return errors to maintain backwards compatibility.
-		},
-	},
+	Websocket:         true,
+	RawWebsocket:      false,
+	JSessionID:        nil,
+	SockJSURL:         "//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js",
+	HeartbeatDelay:    25 * time.Second,
+	DisconnectDelay:   5 * time.Second,
+	ResponseLimit:     128 * 1024,
+	WebsocketUpgrader: nil,
 }
 
 type info struct {

--- a/sockjs/rawwebsocket.go
+++ b/sockjs/rawwebsocket.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *handler) rawWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	conn, err := websocket.Upgrade(rw, req, nil)
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return

--- a/sockjs/rawwebsocket.go
+++ b/sockjs/rawwebsocket.go
@@ -8,7 +8,15 @@ import (
 )
 
 func (h *handler) rawWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := h.upgrader.Upgrade(rw, req, nil)
+	var conn *websocket.Conn
+	var err error
+	if h.options.WebsocketUpgrader != nil {
+		conn, err = h.options.WebsocketUpgrader.Upgrade(rw, req, nil)
+	} else {
+		// use default as before, so that those 2 buffer size variables are used as before
+		conn, err = websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	}
+
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return

--- a/sockjs/rawwebsocket.go
+++ b/sockjs/rawwebsocket.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *handler) rawWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := websocket.Upgrade(rw, req, nil)
+	conn, err := h.upgrader.Upgrade(rw, req, nil)
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return

--- a/sockjs/rawwebsocket_test.go
+++ b/sockjs/rawwebsocket_test.go
@@ -119,3 +119,37 @@ func TestHandler_RawWebSocketCommunication(t *testing.T) {
 	}
 	<-done
 }
+
+func TestHandler_RawCustomWebSocketCommunication(t *testing.T) {
+	h := newTestHandler()
+	h.options.WebsocketUpgrader = &websocket.Upgrader{
+		ReadBufferSize:  0,
+		WriteBufferSize: 0,
+		CheckOrigin:     func(_ *http.Request) bool { return true },
+		Error:           func(w http.ResponseWriter, r *http.Request, status int, reason error) {},
+	}
+	server := httptest.NewServer(http.HandlerFunc(h.rawWebsocket))
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		conn.Send("message 1")
+		conn.Send("message 2")
+		expected := "[\"message 3\"]\n"
+		msg, err := conn.Recv()
+		if msg != expected || err != nil {
+			t.Errorf("Got '%s', expected '%s'", msg, expected)
+		}
+		conn.Close(123, "close")
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.WriteJSON([]string{"message 3"})
+	var expected = []string{"message 1", "message 2"}
+	for _, exp := range expected {
+		_, msg, err := conn.ReadMessage()
+		if string(msg) != exp || err != nil {
+			t.Errorf("Wrong frame, got '%s' and error '%v', expected '%s' without error", msg, err, exp)
+		}
+	}
+	<-done
+}

--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -17,7 +17,7 @@ var WebSocketReadBufSize = 4096
 var WebSocketWriteBufSize = 4096
 
 func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := websocket.Upgrade(rw, req, nil)
+	conn, err := h.upgrader.Upgrade(rw, req, nil)
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return

--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -17,7 +17,7 @@ var WebSocketReadBufSize = 4096
 var WebSocketWriteBufSize = 4096
 
 func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	conn, err := websocket.Upgrade(rw, req, nil)
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return

--- a/sockjs/websocket.go
+++ b/sockjs/websocket.go
@@ -17,7 +17,14 @@ var WebSocketReadBufSize = 4096
 var WebSocketWriteBufSize = 4096
 
 func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
-	conn, err := h.upgrader.Upgrade(rw, req, nil)
+	var conn *websocket.Conn
+	var err error
+	if h.options.WebsocketUpgrader != nil {
+		conn, err = h.options.WebsocketUpgrader.Upgrade(rw, req, nil)
+	} else {
+		// use default as before, so that those 2 buffer size variables are used as before
+		conn, err = websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	}
 	if _, ok := err.(websocket.HandshakeError); ok {
 		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
 		return


### PR DESCRIPTION
This pull request adds a new option `WebsocketCompression` that when used will allow supported clients to receive and send compressed messages.  This is a minimal approach that should be backwards compatible with the current implementation.

It takes cues from some prior art:

https://github.com/igm/sockjs-go/pull/56 (Switches to use `websocket.Updater` but made several other changes)
https://github.com/igm/sockjs-go/pull/53 (Enabled compression always rather than made it configurable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/igm/sockjs-go/62)
<!-- Reviewable:end -->
