### PR TITLE
Improve performance for session id parser

### DIFF
--- a/sockjs/benchmarks_test.go
+++ b/sockjs/benchmarks_test.go
@@ -151,7 +151,7 @@ func BenchmarkMessageWebsocket(b *testing.B) {
 }
 
 func BenchmarkHandler_ParseSessionID(b *testing.B) {
-	h := handler{prefix: "/prefix"}
+	h := newHandler("/prefix", testOptions, nil)
 	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
 
 	b.ReportAllocs()

--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -10,12 +10,14 @@ import (
 )
 
 var (
-	prefixRegexp   = make(map[string]*regexp.Regexp)
-	prefixRegexpMu sync.Mutex // protects prefixRegexp
+	plainPrefixRe = regexp.MustCompile(`^[0-9a-zA-Z\-_/]*`)
+
+	errUnableToParseSessionID = errors.New("unable to parse URL for session")
 )
 
 type handler struct {
 	prefix      string
+	prefixRe    *regexp.Regexp // nil when the prefix is not regex-like.
 	options     Options
 	handlerFunc func(Session)
 	mappings    []*mapping
@@ -31,8 +33,18 @@ func NewHandler(prefix string, opts Options, handleFunc func(Session)) http.Hand
 }
 
 func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler {
+	var prefixRe *regexp.Regexp
+	if !plainPrefixRe.MatchString(prefix) { // whether a prefix is regex-like?
+		p := prefix
+		if !strings.HasPrefix(prefix, "^") {
+			p = "^" + p
+		}
+		prefixRe = regexp.MustCompile(p)
+	}
+
 	h := &handler{
 		prefix:      prefix,
+		prefixRe:    prefixRe,
 		options:     opts,
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
@@ -95,20 +107,27 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *handler) parseSessionID(url *url.URL) (string, error) {
-	// cache compiled regexp objects for most used prefixes
-	prefixRegexpMu.Lock()
-	session, ok := prefixRegexp[h.prefix]
-	if !ok {
-		session = regexp.MustCompile(h.prefix + "/(?P<server>[^/.]+)/(?P<session>[^/.]+)/.*")
-		prefixRegexp[h.prefix] = session
-	}
-	prefixRegexpMu.Unlock()
+	urlPath := url.Path
+	prefix := h.prefix
 
-	matches := session.FindStringSubmatch(url.Path)
-	if len(matches) == 3 {
-		return matches[2], nil
+	if h.prefixRe != nil {
+		prefix = h.prefixRe.FindString(urlPath)
+		if prefix == "" {
+			return "", errUnableToParseSessionID
+		}
 	}
-	return "", errors.New("unable to parse URL for session")
+
+	subPath := strings.TrimPrefix(urlPath, prefix+"/")
+	if len(subPath) == len(urlPath) { // no trim performed
+		return "", errUnableToParseSessionID
+	}
+
+	parts := strings.SplitN(subPath, "/", 3)
+	if len(parts) != 3 {
+		return "", errUnableToParseSessionID
+	}
+
+	return parts[1], nil
 }
 
 func (h *handler) sessionByRequest(req *http.Request) (*session, error) {

--- a/sockjs/handler_test.go
+++ b/sockjs/handler_test.go
@@ -34,11 +34,27 @@ func TestHandler_Create(t *testing.T) {
 	}
 }
 
-func TestHandler_ParseSessionId(t *testing.T) {
-	h := handler{prefix: "/prefix"}
+func TestHandler_ParseSessionID_Plain(t *testing.T) {
+	h := newHandler("/prefix", testOptions, nil)
 	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
 	if session, err := h.parseSessionID(url); session != "session" || err != nil {
 		t.Errorf("Wrong session parsed, got '%s' expected '%s' with error = '%v'", session, "session", err)
+	}
+	url, _ = url.Parse("http://server:80/asdasd/server/session/whatever")
+	if _, err := h.parseSessionID(url); err == nil {
+		t.Errorf("Should return error")
+	}
+}
+
+func TestHandler_ParseSessionID_Regex(t *testing.T) {
+	h := newHandler("/prefix/[0-9]+", testOptions, nil)
+	url, _ := url.Parse("http://server:80/prefix/123/server/session/whatever")
+	if session, err := h.parseSessionID(url); session != "session" || err != nil {
+		t.Errorf("Wrong session parsed, got '%s' expected '%s' with error = '%v'", session, "session", err)
+	}
+	url, _ = url.Parse("http://server:80/prefix/asdasd/server/session/whatever")
+	if _, err := h.parseSessionID(url); err == nil {
+		t.Errorf("Should return error")
 	}
 	url, _ = url.Parse("http://server:80/asdasd/server/session/whatever")
 	if _, err := h.parseSessionID(url); err == nil {


### PR DESCRIPTION
By eliminating the use of regex (and mutex), the performance shall greatly improved, see the benchmark:

*PS: I saw some application use regex in prefix, so I choose to keep that behavior.*

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/igm/sockjs-go/sockjs
BenchmarkHandler_ParseSessionID          2000000              1035 ns/op             112 B/op          2 allocs/op
BenchmarkHandler_ParseSessionID-2        1000000              1001 ns/op             112 B/op          2 allocs/op
BenchmarkHandler_ParseSessionID-4        2000000               948 ns/op             112 B/op          2 allocs/op
BenchmarkHandler_ParseSessionID-8        2000000               953 ns/op             112 B/op          2 allocs/op
PASS
ok      github.com/igm/sockjs-go/sockjs 9.711s
```

After:
```
goos: darwin
goarch: amd64
pkg: github.com/igm/sockjs-go/sockjs
BenchmarkHandler_ParseSessionID         10000000               143 ns/op              48 B/op          1 allocs/op
BenchmarkHandler_ParseSessionID-2       10000000               135 ns/op              48 B/op          1 allocs/op
BenchmarkHandler_ParseSessionID-4       10000000               137 ns/op              48 B/op          1 allocs/op
BenchmarkHandler_ParseSessionID-8       10000000               138 ns/op              48 B/op          1 allocs/op
PASS
ok      github.com/igm/sockjs-go/sockjs 6.152s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/igm/sockjs-go/67)
<!-- Reviewable:end -->
