### PR TITLE
Propagate request context into sockjs session

### DIFF
--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -1,6 +1,7 @@
 package sockjs
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sync"
@@ -215,4 +216,11 @@ func (s *session) GetSessionState() SessionState {
 
 func (s *session) Request() *http.Request {
 	return s.req
+}
+
+func (s *session) Context() context.Context {
+	if s.req != nil {
+		return s.req.Context()
+	}
+	return nil
 }

--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -1,6 +1,9 @@
 package sockjs
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // Session represents a connection between server and client.
 type Session interface {
@@ -16,4 +19,6 @@ type Session interface {
 	Close(status uint32, reason string) error
 	//Gets the state of the session. SessionOpening/SessionActive/SessionClosing/SessionClosed;
 	GetSessionState() SessionState
+	// Context returns the session context (derived from the HTTP request)
+	Context() context.Context
 }


### PR DESCRIPTION
This exposes the HTTP request context via the Session interface, which I would like to use in my code as I populate fields in the originating HTTP request context that I'd like to add to use elsewhere in my sockjs session.

The other way to do this would be to not add any additional methods to the struct, and instead make the Request method be part of the Session interface.