### PR TITLE
Add origin option so CORS can be configured to a specified policy

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -37,7 +37,7 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
 	}
-
+	xhrCors := xhrCorsFactory(opts.Origin)
 	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
 	h.mappings = []*mapping{
 		newMapping("GET", prefix+"[/]?$", welcomeHandler),

--- a/sockjs/options.go
+++ b/sockjs/options.go
@@ -58,6 +58,9 @@ type Options struct {
 	// This setting controls if the server should set this cookie to a dummy value.
 	// By default setting JSessionID cookie is disabled. More sophisticated behaviour can be achieved by supplying a function.
 	JSessionID func(http.ResponseWriter, *http.Request)
+	// CORS origin to be set on outgoing responses. If set to the empty string, it will default to the
+	// incoming `Origin` header, or "*" if the Origin header isn't set.
+	Origin string
 }
 
 // DefaultOptions is a convenient set of options to be used for sockjs

--- a/sockjs/web.go
+++ b/sockjs/web.go
@@ -6,18 +6,23 @@ import (
 	"time"
 )
 
-func xhrCors(rw http.ResponseWriter, req *http.Request) {
-	header := rw.Header()
-	origin := req.Header.Get("origin")
-	if origin == "" {
-		origin = "*"
-	}
-	header.Set("Access-Control-Allow-Origin", origin)
+func xhrCorsFactory(defaultOrigin string) func(rw http.ResponseWriter, req *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		header := rw.Header()
+		origin := defaultOrigin
+		if origin == "" {
+			origin = req.Header.Get("origin")
+		}
+		if origin == "" || origin == "null" {
+			origin = "*"
+		}
+		header.Set("Access-Control-Allow-Origin", origin)
 
-	if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
-		header.Add("Access-Control-Allow-Headers", allowHeaders)
+		if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
+			header.Add("Access-Control-Allow-Headers", allowHeaders)
+		}
+		header.Set("Access-Control-Allow-Credentials", "true")
 	}
-	header.Set("Access-Control-Allow-Credentials", "true")
 }
 
 func xhrOptions(rw http.ResponseWriter, req *http.Request) {

--- a/sockjs/web_test.go
+++ b/sockjs/web_test.go
@@ -10,6 +10,7 @@ import (
 func TestXhrCors(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors := xhrCorsFactory("")
 	xhrCors(recorder, req)
 	acao := recorder.Header().Get("access-control-allow-origin")
 	if acao != "*" {


### PR DESCRIPTION
### Summary

For most purposes this change should be backwards-compatible as it's additive to the struct, and if unset the behavior remains mostly the same.

- Adds an `Origin` option to the sockjs config. 

- If `Origin` is specified, `Access-Control-Allow-Origin` will return that value every time. If not specified, we fall back to the value of the incoming `Origin` header (as previously). If no `Origin` header is given, we return `Access-Control-Allow-Origin: *`

### Impact

Some organizations consider it a security issue to echo `Origin` headers in `Access-Control-Allow-Origin`. This is mostly bogus: `Origin` headers cannot be spoofed by browser clients, and non-browser clients (i.e.: `curl`) don't obey `Access-Control-Allow-Origin` because the setting is really only meaningful from a DOM context.

Additionally, the `Access-Control` portion is probably misleading. ACAO is not meant to actually be used for access control, i.e.: authentication. The purpose of ACAO is to prevent unauthorized third-party resources from being consumed cross-domain. For example, the API backing your bank's web user interface doesn't want to be consumed by a page running on `evilsite.com`. For a more realistic attack, consider your bank's API being consumed by `vvellsfargo.com`, tricking you into draining your account all using API calls from your own IP address.

Nevertheless, because this is poorly understood by many organizations, some require the ability to set the `Access-Control-Allow-Origin` header on every outgoing request per their internal security policy. This is reasonable and easily accomplished by this PR.

### Additional Resources

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/igm/sockjs-go/73)
<!-- Reviewable:end -->
