### PR TITLE
Run gofmt on session.go

### DIFF
--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -68,8 +68,8 @@ type receiver interface {
 func newSession(req *http.Request, sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration) *session {
 
 	s := &session{
-		id:  sessionID,
-		req: req,
+		id:                     sessionID,
+		req:                    req,
 		sessionTimeoutInterval: sessionTimeoutInterval,
 		heartbeatInterval:      heartbeatInterval,
 		recvBuffer:             newMessageBuffer(),


### PR DESCRIPTION
Ran a gofmt checker across the repo and `session.go` popped up.

After this change, the entire repo should be consistently `gofmt`ted. 

https://golang.org/misc/git/pre-commit - useful for contributors

https://github.com/google/gopacket/blob/master/.travis.gofmt.sh - could be a good way to enforce gofmt in travis