### PR TITLE
add CheckOrigin function

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -37,7 +37,7 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		handlerFunc: handlerFunc,
 		sessions:    make(map[string]*session),
 	}
-	xhrCors := xhrCorsFactory(opts.Origin)
+	xhrCors := xhrCorsFactory(opts)
 	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
 	h.mappings = []*mapping{
 		newMapping("GET", prefix+"[/]?$", welcomeHandler),

--- a/sockjs/options.go
+++ b/sockjs/options.go
@@ -61,6 +61,13 @@ type Options struct {
 	// CORS origin to be set on outgoing responses. If set to the empty string, it will default to the
 	// incoming `Origin` header, or "*" if the Origin header isn't set.
 	Origin string
+	// CheckOrigin allows to dynamically decide whether server should set CORS
+	// headers or not in case of XHR requests. When true returned CORS will be
+	// configured with allowed origin equal to incoming `Origin` header, or "*"
+	// if the request Origin header isn't set. When false returned CORS headers
+	// won't be set at all. If this function is nil then Origin option above will
+	// be taken into account.
+	CheckOrigin func(*http.Request) bool
 }
 
 // DefaultOptions is a convenient set of options to be used for sockjs

--- a/sockjs/web_test.go
+++ b/sockjs/web_test.go
@@ -10,7 +10,7 @@ import (
 func TestXhrCors(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	xhrCors := xhrCorsFactory("")
+	xhrCors := xhrCorsFactory(Options{})
 	xhrCors(recorder, req)
 	acao := recorder.Header().Get("access-control-allow-origin")
 	if acao != "*" {
@@ -22,7 +22,6 @@ func TestXhrCors(t *testing.T) {
 	if acao != "localhost" {
 		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "localhost")
 	}
-
 	req.Header.Set("access-control-request-headers", "some value")
 	rec := httptest.NewRecorder()
 	xhrCors(rec, req)
@@ -43,6 +42,53 @@ func TestXhrCors(t *testing.T) {
 	acac := rec.Header()["Access-Control-Allow-Credentials"]
 	if len(acac) != 1 || acac[0] != "true" {
 		t.Errorf("Incorent value for ACAC, got %s", strings.Join(acac, ","))
+	}
+}
+
+func TestCheckOriginCORSAllowedNullOrigin(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors := xhrCorsFactory(Options{
+		CheckOrigin: func(req *http.Request) bool {
+			return true
+		},
+	})
+	req.Header.Set("origin", "null")
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "null" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "null")
+	}
+}
+
+func TestCheckOriginCORSAllowedEmptyOrigin(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors := xhrCorsFactory(Options{
+		CheckOrigin: func(req *http.Request) bool {
+			return true
+		},
+	})
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "*" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "*")
+	}
+}
+
+func TestCheckOriginCORSNotAllowed(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors := xhrCorsFactory(Options{
+		CheckOrigin: func(req *http.Request) bool {
+			return false
+		},
+	})
+	req.Header.Set("origin", "localhost")
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "")
 	}
 }
 


### PR DESCRIPTION
Hello @igm, I am also not very happy with changes in #73 because it does not allow to properly restrict CORS to several origins. This pull request provides this possibility, solves a problem with local files mentioned in #75 , also it allows to completely disable setting CORS headers when `false` returned from `CheckOrigin` function (makes it a bit closer to [what is possible with sockjs-node](https://github.com/sockjs/sockjs-node/blob/14a5c3cf097126bde74436d001816c53a0593d43/src/trans-xhr.coffee#L60)).

I am not sure this is the best way to solve as there are actually lots of possible ways. So open to discuss a proper solution.

When using `CheckOrigin` function added here users can handle [null](https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null) origin case returning `false` to not allow CORS for null origins. Does not seems very obvious and can be error-prone but I don't see a better solution at moment.

Also `CheckOrigin` added here is very similar to [CheckOrigin](https://github.com/gorilla/websocket/blob/master/server.go#L66) from Gorilla WebSocket Upgrader. Having a function with the same name but not used for WebSocket can be confusing and we most probably should consider renaming it (to sth like `CheckXHROrigin`, `CheckCORS` 
 etc).

One more alternative I have in my mind is adding function like `GetOrigin(*http.Request) string` instead. Library users should return origin string based on application internal logic. If empty string returned we can completely disable CORS. But it's a bit harder to use because looks like users must return `*` explicitly if origin header not set.