### PR TITLE
Fix running SockJS handler on root prefix

### DIFF
--- a/sockjs/handler.go
+++ b/sockjs/handler.go
@@ -38,11 +38,15 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		sessions:    make(map[string]*session),
 	}
 	xhrCors := xhrCorsFactory(opts)
-	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
+	matchPrefix := prefix
+	if matchPrefix == "" {
+		matchPrefix = "^"
+	}
+	sessionPrefix := matchPrefix + "/[^/.]+/[^/.]+"
 	h.mappings = []*mapping{
-		newMapping("GET", prefix+"[/]?$", welcomeHandler),
-		newMapping("OPTIONS", prefix+"/info$", opts.cookie, xhrCors, cacheFor, opts.info),
-		newMapping("GET", prefix+"/info$", xhrCors, noCache, opts.info),
+		newMapping("GET", matchPrefix+"[/]?$", welcomeHandler),
+		newMapping("OPTIONS", matchPrefix+"/info$", opts.cookie, xhrCors, cacheFor, opts.info),
+		newMapping("GET", matchPrefix+"/info$", xhrCors, noCache, opts.info),
 		// XHR
 		newMapping("POST", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, noCache, h.xhrSend),
 		newMapping("OPTIONS", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, cacheFor, xhrOptions),
@@ -59,13 +63,13 @@ func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler
 		newMapping("OPTIONS", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, cacheFor, xhrOptions),
 		newMapping("POST", sessionPrefix+"/jsonp_send$", opts.cookie, xhrCors, noCache, h.jsonpSend),
 		// IFrame
-		newMapping("GET", prefix+"/iframe[0-9-.a-z_]*.html$", cacheFor, h.iframe),
+		newMapping("GET", matchPrefix+"/iframe[0-9-.a-z_]*.html$", cacheFor, h.iframe),
 	}
 	if opts.Websocket {
 		h.mappings = append(h.mappings, newMapping("GET", sessionPrefix+"/websocket$", h.sockjsWebsocket))
 	}
 	if opts.RawWebsocket {
-		h.mappings = append(h.mappings, newMapping("GET", prefix+"/websocket$", h.rawWebsocket))
+		h.mappings = append(h.mappings, newMapping("GET", matchPrefix+"/websocket$", h.rawWebsocket))
 	}
 	return h
 }

--- a/sockjs/handler_test.go
+++ b/sockjs/handler_test.go
@@ -1,6 +1,8 @@
 package sockjs
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -31,6 +33,35 @@ func TestHandler_Create(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestHandler_RootPrefixInfoHandler(t *testing.T) {
+	handler := newHandler("", testOptions, nil)
+	if handler.Prefix() != "" {
+		t.Errorf("Prefix not properly set, got '%s' expected '%s'", handler.Prefix(), "")
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/info")
+	if err != nil {
+		t.Errorf("There should not be any error, got '%s'", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
+	}
+	infoData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error reading body: '%v'", err)
+	}
+	var i info
+	err = json.Unmarshal(infoData, &i)
+	if err != nil {
+		t.Fatalf("Error unmarshaling info: '%v', data was: '%s'", err, string(infoData))
+	}
+	if i.Websocket != true {
+		t.Fatalf("Expected websocket to be true")
 	}
 }
 


### PR DESCRIPTION
It's not possible to run SockJS handler on root prefix at moment. Without these changes test failed with:
```
--- FAIL: TestHandler_RootPrefixInfoHandler (0.00s)
    handler_test.go:61: Error unmarshaling info: 'invalid character 'W' looking for beginning of value', data was: 'Welcome to SockJS!
        '
FAIL
exit status 1
FAIL	github.com/igm/sockjs-go/sockjs	0.191s
```

The reason is that welcome handler path regexp matches all strings when `prefix` is empty string. [Playground](https://play.golang.org/p/m7Y_4NA5PLo)

Looks like the best way to solve is to add `^` to all mappings, but I only added it to handlers match string in case `prefix` is empty string for maximum backwards compatibility.