### PR TITLE
Various tests updates to make tests stable

### DIFF
--- a/sockjs/eventsource_test.go
+++ b/sockjs/eventsource_test.go
@@ -13,14 +13,20 @@ func TestHandler_EventSource(t *testing.T) {
 	h := newTestHandler()
 	h.options.ResponseLimit = 1024
 	go func() {
-		time.Sleep(1 * time.Millisecond)
-		h.sessionsMux.Lock()
-		defer h.sessionsMux.Unlock()
-		sess := h.sessions["session"]
-		sess.Lock()
-		defer sess.Unlock()
-		recv := sess.recv
-		recv.close()
+		var sess *session
+		for exists := false; !exists; {
+			h.sessionsMux.Lock()
+			sess, exists = h.sessions["session"]
+			h.sessionsMux.Unlock()
+		}
+		for exists := false; !exists; {
+			sess.RLock()
+			exists = sess.recv != nil
+			sess.RUnlock()
+		}
+		sess.RLock()
+		sess.recv.close()
+		sess.RUnlock()
 	}()
 	h.eventSource(rw, req)
 	contentType := rw.Header().Get("content-type")
@@ -65,7 +71,11 @@ func TestHandler_EventSourceConnectionInterrupted(t *testing.T) {
 	rw := newClosableRecorder()
 	close(rw.closeNotifCh)
 	h.eventSource(rw, req)
-	time.Sleep(1 * time.Millisecond)
+	select {
+	case <-sess.closeCh:
+	case <-time.After(1 * time.Second):
+		t.Errorf("session close channel should be closed")
+	}
 	sess.Lock()
 	if sess.state != SessionClosed {
 		t.Errorf("Session should be closed")

--- a/sockjs/handler_test.go
+++ b/sockjs/handler_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 var testOptions = DefaultOptions
@@ -28,9 +30,8 @@ func TestHandler_Create(t *testing.T) {
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + "/echo")
-	if err != nil {
-		t.Errorf("There should not be any error, got '%s'", err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
 	}
@@ -45,9 +46,9 @@ func TestHandler_RootPrefixInfoHandler(t *testing.T) {
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + "/info")
-	if err != nil {
-		t.Errorf("There should not be any error, got '%s'", err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
 	}

--- a/sockjs/session_test.go
+++ b/sockjs/session_test.go
@@ -92,7 +92,12 @@ func TestSession_Timeout(t *testing.T) {
 	select {
 	case <-sess.closeCh:
 	case <-time.After(20 * time.Millisecond):
-		t.Errorf("sess close notification channel should close")
+		select {
+		case <-sess.closeCh:
+			// still ok
+		default:
+			t.Errorf("sess close notification channel should close")
+		}
 	}
 	if sess.GetSessionState() != SessionClosed {
 		t.Errorf("Session did not timeout")


### PR DESCRIPTION
* changed logic to wait for interrupt channel to close before checking receiver state rather to rely on lock mechanism
* replaced time.Sleep with active loop to get session and receiver
* some test updates to use `testify/require` to check for `nil` so that tests don't panic with `nil`