### PR TITLE
Expose the type of receiver against the session

### DIFF
--- a/sockjs/session.go
+++ b/sockjs/session.go
@@ -205,6 +205,20 @@ func (s *session) Send(msg string) error {
 	return s.sendMessage(msg)
 }
 
+func (s *session) ReceiverType() string {
+	if s.recv != nil {
+		switch s.recv.(type) {
+		case *wsReceiver:
+			return "Websocket"
+		case *rawWsReceiver:
+			return "Raw Websocket"
+		case *httpReceiver:
+			return "HTTP Fallback"
+		}
+	}
+	return "None"
+}
+
 func (s *session) ID() string { return s.id }
 
 func (s *session) GetSessionState() SessionState {

--- a/sockjs/sockjs.go
+++ b/sockjs/sockjs.go
@@ -6,6 +6,8 @@ import "net/http"
 type Session interface {
 	// Id returns a session id
 	ID() string
+	// ReceiverType returns the connection handler type
+	ReceiverType() string
 	// Request returns the first http request
 	Request() *http.Request
 	// Recv reads one text frame from session


### PR DESCRIPTION
This is useful for diagnostics or logging when fallback mechanisms are in use