### PR TITLE
Introduction version v2 as go module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.14.x"
-  - tip
+  - 1.14.x
 
 before_install:
   - go get golang.org/x/tools/cmd/cover
@@ -16,4 +15,4 @@ install:
   - go get -d -v -t ./...
 
 script:
-  - go test -v -race ./...
+  - go test -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,19 @@
-sudo: false
 language: go
 
 go:
-  - "1.13.x"
-  - "1.12.x"
+  - "1.14.x"
   - tip
-
-notifications:
-  email:
-  - igor.mihalik+travis@gmail.com
 
 before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 
 after_success:
-  - go test ./sockjs -coverprofile=profile.out -covermode=count
+  - go test ./... -coverprofile=profile.out -covermode=count
   - PATH=$HOME/gopath/bin:$PATH goveralls -coverprofile=profile.out -service=travis-ci
 
 install:
   - go get -d -v -t ./...
 
 script:
-  - go test ./sockjs -v -race
+  - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -15,25 +15,32 @@ SockJS-Go server library
 
 SockJS-Go is a [SockJS](https://github.com/sockjs/sockjs-client) server library written in Go.
 
-To use current stable version **v2**
+To use current stable version **v2** use the import path:
 
-    go get gopkg.in/igm/sockjs-go.v2/sockjs
-
-To use previous version **v1** (DEPRECATED)
-
-    go get gopkg.in/igm/sockjs-go.v1/sockjs
-
-To install **development** version of `sockjs-go` run:
-
-    go get github.com/igm/sockjs-go/sockjs
+    github.com/igm/sockjs-go/v2/sockjs
 
 
 Versioning
 -
 
-SockJS-Go project adopted [gopkg.in](http://gopkg.in) approach for versioning. SockJS-Go library details can be found [here](https://gopkg.in/igm/sockjs-go.v2/sockjs)
+Each version should have different import path and thus in the beginning 
+SockJS-Go project adopted [gopkg.in](http://gopkg.in) approach for versioning. 
 
+With the introduction of [go modules](https://golang.org/doc/go1.11#modules) we adopted
+the standard and update the source layout accordingly. 
 
+All the development for *all versions* happens in `master`. Branches `v2` and `v1` will 
+remain in the repository for backwards compatibility reasons so that
+importing `gopkg.in/igm/sockjs-go.v2/sockjs` will work as before. 
+No further functionality will be added into those branches.
+
+Migration to go mod
+--
+
+In order to migrate existing project to go modules change the import path from
+`gopkg.in/igm/sockjs-go.v2/sockjs` to `github.com/igm/sockjs-go/v2/sockjs` in the codebase.
+
+ 
 Example
 -
 
@@ -47,7 +54,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	"github.com/igm/sockjs-go/v2/sockjs"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://api.travis-ci.org/igm/sockjs-go.svg?branch=v2)](https://travis-ci.org/igm/sockjs-go) [![GoDoc](http://godoc.org/gopkg.in/igm/sockjs-go.v2/sockjs?status.svg)](http://godoc.org/gopkg.in/igm/sockjs-go.v2/sockjs) [![Coverage Status](https://coveralls.io/repos/igm/sockjs-go/badge.svg?branch=v2)](https://coveralls.io/r/igm/sockjs-go?branch=v2)
+[![Build Status](https://api.travis-ci.org/igm/sockjs-go.svg?branch=v2)](https://travis-ci.org/igm/sockjs-go) 
+[![GoDoc](http://godoc.org/github.com/igm/sockjs-go/v2/sockjs?status.svg)](http://godoc.org/github.com/igm/sockjs-go/v2/sockjs) 
+[![Coverage Status](https://coveralls.io/repos/igm/sockjs-go/badge.svg?branch=v2)](https://coveralls.io/r/igm/sockjs-go?branch=v2)
 
 What is SockJS?
 =
@@ -27,10 +29,10 @@ Each version should have different import path and thus in the beginning
 SockJS-Go project adopted [gopkg.in](http://gopkg.in) approach for versioning. 
 
 With the introduction of [go modules](https://golang.org/doc/go1.11#modules) we adopted
-the standard and update the source layout accordingly. 
+the standard and updated the source layout accordingly. 
 
 All the development for *all versions* happens in `master`. Branches `v2` and `v1` will 
-remain in the repository for backwards compatibility reasons so that
+remain in the repository for backward compatibility reasons so that
 importing `gopkg.in/igm/sockjs-go.v2/sockjs` will work as before. 
 No further functionality will be added into those branches.
 

--- a/v2/examples/webchat/README.md
+++ b/v2/examples/webchat/README.md
@@ -1,0 +1,16 @@
+# Chat Example
+
+Simple sockjs chat example.
+
+## Run
+```shell
+$ go run webchat.go
+```
+Navigate using web browser: http://127.0.0.1:8080
+Open multiple windows with the same URL and see how chat works.
+
+## Docker
+```shell
+$ docker run -p=80:8080 -d imihalik/sockjs-chat
+```
+

--- a/v2/examples/webchat/web/app.js
+++ b/v2/examples/webchat/web/app.js
@@ -1,0 +1,22 @@
+if (!window.location.origin) { // Some browsers (mainly IE) do not have this property, so we need to build it manually...
+  window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? (':' + window.location.port) : '');
+}
+
+
+var sock = new SockJS(window.location.origin+'/echo')
+
+sock.onopen = function() {
+	// console.log('connection open');
+	document.getElementById("status").innerHTML = "connected";
+	document.getElementById("send").disabled=false;
+};
+
+sock.onmessage = function(e) {
+	document.getElementById("output").value += e.data +"\n";
+};
+
+sock.onclose = function() {
+	// console.log('connection closed');
+	document.getElementById("status").innerHTML = "disconnected";
+	document.getElementById("send").disabled=true;
+};

--- a/v2/examples/webchat/web/index.html
+++ b/v2/examples/webchat/web/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script type="text/javascript" src="app.js"></script>
+    <meta charset="UTF-8">
+    <title>Chat Web Example</title>
+</head>
+
+<body>
+<h1>Chat - Web Example</h1>
+<form onSubmit='sock.send(document.getElementById("input").value); return false;'>
+    Input text: <input id="input" focus="true"/>
+    <input type="submit" disabled="true" id="send" value="Send"/>
+</form>
+<br/>
+Messages from server:</br>
+<textarea cols=80 rows=20 id="output">
+</textarea>
+<br/>
+status: <span id="status">connecting...</span>
+
+</body>
+</html>

--- a/v2/examples/webchat/webchat.go
+++ b/v2/examples/webchat/webchat.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/igm/pubsub"
+	"github.com/igm/sockjs-go/v2/sockjs"
+)
+
+var chat pubsub.Publisher
+
+func main() {
+	http.Handle("/echo/", sockjs.NewHandler("/echo", sockjs.DefaultOptions, echoHandler))
+	http.Handle("/", http.FileServer(http.Dir("web/")))
+	log.Println("Server started on port: 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func echoHandler(session sockjs.Session) {
+	log.Println("new sockjs session established")
+	var closedSession = make(chan struct{})
+	chat.Publish("[info] new participant joined chat")
+	defer chat.Publish("[info] participant left chat")
+	go func() {
+		reader, _ := chat.SubChannel(nil)
+		for {
+			select {
+			case <-closedSession:
+				return
+			case msg := <-reader:
+				if err := session.Send(msg.(string)); err != nil {
+					return
+				}
+			}
+
+		}
+	}()
+	for {
+		if msg, err := session.Recv(); err == nil {
+			chat.Publish(msg)
+			continue
+		}
+		break
+	}
+	close(closedSession)
+	log.Println("sockjs session closed")
+}

--- a/v2/examples/webecho/README.md
+++ b/v2/examples/webecho/README.md
@@ -1,0 +1,9 @@
+# Echo Example
+
+Simple echo sockjs example.
+
+## Run
+```shell
+$ go run webecho.go
+```
+Navigate using web browser: http://127.0.0.1:8080

--- a/v2/examples/webecho/web/app.js
+++ b/v2/examples/webecho/web/app.js
@@ -1,0 +1,34 @@
+if (!window.location.origin) { // Some browsers (mainly IE) do not have this property, so we need to build it manually...
+  window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? (':' + window.location.port) : '');
+}
+
+var origin = window.location.origin;
+
+// options usage example
+var options = {
+		debug: true,
+		devel: true,
+		protocols_whitelist: ['websocket', 'xdr-streaming', 'xhr-streaming', 'iframe-eventsource', 'iframe-htmlfile', 'xdr-polling', 'xhr-polling', 'iframe-xhr-polling', 'jsonp-polling']
+};
+
+var sock = new SockJS(origin+'/echo', undefined, options);
+
+sock.onopen = function() {
+	//console.log('connection open');
+	document.getElementById("status").innerHTML = "connected";
+	document.getElementById("send").disabled=false;
+};
+
+sock.onmessage = function(e) {
+	document.getElementById("output").value += e.data +"\n";
+};
+
+sock.onclose = function() {
+	document.getElementById("status").innerHTML = "connection closed";
+	//console.log('connection closed');
+};
+
+function send() {
+	text = document.getElementById("input").value;
+	sock.send(document.getElementById("input").value); return false;
+}

--- a/v2/examples/webecho/web/index.html
+++ b/v2/examples/webecho/web/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script type="text/javascript" src="app.js"></script>
+    <meta charset="UTF-8">
+    <title>Echo Web Example</title>
+</head>
+
+<body>
+<h1>Echo - Web Example</h1>
+<form onSubmit='sock.send(document.getElementById("input").value); return false;'>
+    Input text: <input id="input" focus="true"/>
+    <input type="submit" disabled="true" id="send" value="Send"/>
+</form>
+<br/>
+Messages from server:</br>
+<textarea cols=80 rows=20 id="output">
+</textarea>
+<br/>
+status: <span id="status">connecting...</span>
+
+</body>
+</html>

--- a/v2/examples/webecho/webecho.go
+++ b/v2/examples/webecho/webecho.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/igm/sockjs-go/v2/sockjs"
+)
+
+var (
+	websocket = flag.Bool("websocket", true, "enable/disable websocket protocol")
+)
+
+func init() {
+	flag.Parse()
+}
+
+func main() {
+	opts := sockjs.DefaultOptions
+	opts.Websocket = *websocket
+	handler := sockjs.NewHandler("/echo", opts, echoHandler)
+	http.Handle("/echo/", handler)
+	http.Handle("/", http.FileServer(http.Dir("web/")))
+	log.Println("Server started on port: 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func echoHandler(session sockjs.Session) {
+	log.Println("new sockjs session established")
+	for {
+		if msg, err := session.Recv(); err == nil {
+			session.Send(msg)
+			continue
+		}
+		break
+	}
+	log.Println("sockjs session closed")
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,9 @@
+module github.com/igm/sockjs-go/v2
+
+go 1.14
+
+require (
+	github.com/gorilla/websocket v1.4.2
+	github.com/igm/pubsub v1.0.0
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,7 @@
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/igm/pubsub v1.0.0/go.mod h1:q4OjwAiOVflOQD1dXrh3QfJ+IqTG/xiQIvZwDeQIiqY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/v2/sockjs/benchmarks_test.go
+++ b/v2/sockjs/benchmarks_test.go
@@ -1,0 +1,94 @@
+package sockjs
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func BenchmarkSimple(b *testing.B) {
+	var messages = make(chan string, 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for m := range messages {
+			session.Send(m)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", 1000), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		messages <- "some message"
+	}
+	fmt.Println(b.N)
+	close(messages)
+	resp.Body.Close()
+}
+
+func BenchmarkMessages(b *testing.B) {
+	msg := strings.Repeat("m", 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for n := 0; n < b.N; n++ {
+			session.Send(msg)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(session int) {
+			reqc := 0
+			// req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", session), nil)
+			req, _ := http.NewRequest("GET", server.URL+fmt.Sprintf("/echo/server/%d/eventsource", session), nil)
+			for {
+				reqc++
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					log.Fatal(err)
+				}
+				reader := bufio.NewReader(resp.Body)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						goto AGAIN
+					}
+					if strings.HasPrefix(line, "data: c[1024") {
+						resp.Body.Close()
+						goto DONE
+					}
+				}
+			AGAIN:
+				resp.Body.Close()
+			}
+		DONE:
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	server.Close()
+}
+
+func BenchmarkHandler_ParseSessionID(b *testing.B) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.parseSessionID(url)
+	}
+}

--- a/v2/sockjs/doc.go
+++ b/v2/sockjs/doc.go
@@ -1,0 +1,5 @@
+/*
+Package sockjs is a server side implementation of sockjs protocol.
+*/
+
+package sockjs

--- a/v2/sockjs/eventsource.go
+++ b/v2/sockjs/eventsource.go
@@ -1,0 +1,32 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (h *handler) eventSource(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/event-stream; charset=UTF-8")
+	fmt.Fprintf(rw, "\r\n")
+	rw.(http.Flusher).Flush()
+
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(eventSourceFrameWriter))
+	sess, _ := h.sessionByRequest(req)
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type eventSourceFrameWriter struct{}
+
+func (*eventSourceFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "data: %s\r\n\r\n", frame)
+}

--- a/v2/sockjs/eventsource_test.go
+++ b/v2/sockjs/eventsource_test.go
@@ -1,0 +1,73 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandler_EventSource(t *testing.T) {
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		h.sessionsMux.Lock()
+		defer h.sessionsMux.Unlock()
+		sess := h.sessions["session"]
+		sess.Lock()
+		defer sess.Unlock()
+		recv := sess.recv
+		recv.close()
+	}()
+	h.eventSource(rw, req)
+	contentType := rw.Header().Get("content-type")
+	expected := "text/event-stream; charset=UTF-8"
+	if contentType != expected {
+		t.Errorf("Unexpected content type, got '%s', extected '%s'", contentType, expected)
+	}
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+
+	if rw.Body.String() != "\r\ndata: o\r\n\r\n" {
+		t.Errorf("Event stream prelude, got '%s'", rw.Body)
+	}
+}
+
+func TestHandler_EventSourceMultipleConnections(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/sess/eventsource", nil)
+	go func() {
+		rw := &ClosableRecorder{httptest.NewRecorder(), nil}
+		h.eventSource(rw, req)
+		if rw.Body.String() != "\r\ndata: c[2010,\"Another connection still open\"]\r\n\r\n" {
+			t.Errorf("wrong, got '%v'", rw.Body)
+		}
+		h.sessionsMux.Lock()
+		sess := h.sessions["sess"]
+		sess.close()
+		h.sessionsMux.Unlock()
+	}()
+	h.eventSource(rw, req)
+}
+
+func TestHandler_EventSourceConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = sessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.eventSource(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}

--- a/v2/sockjs/example_handler_test.go
+++ b/v2/sockjs/example_handler_test.go
@@ -1,0 +1,39 @@
+package sockjs_test
+
+import (
+	"net/http"
+
+	"github.com/igm/sockjs-go/v2/sockjs"
+)
+
+func ExampleNewHandler_simple() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	http.ListenAndServe(":8080", handler)
+}
+
+func ExampleNewHandler_defaultMux() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	// need to provide path prefix for http.Mux
+	http.Handle("/echo/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/v2/sockjs/frame.go
+++ b/v2/sockjs/frame.go
@@ -1,0 +1,11 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func closeFrame(status uint32, reason string) string {
+	bytes, _ := json.Marshal([]interface{}{status, reason})
+	return fmt.Sprintf("c%s", string(bytes))
+}

--- a/v2/sockjs/frame_test.go
+++ b/v2/sockjs/frame_test.go
@@ -1,0 +1,10 @@
+package sockjs
+
+import "testing"
+
+func TestCloseFrame(t *testing.T) {
+	cf := closeFrame(1024, "some close text")
+	if cf != "c[1024,\"some close text\"]" {
+		t.Errorf("Wrong close frame generated '%s'", cf)
+	}
+}

--- a/v2/sockjs/handler.go
+++ b/v2/sockjs/handler.go
@@ -1,0 +1,133 @@
+package sockjs
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	prefixRegexp   = make(map[string]*regexp.Regexp)
+	prefixRegexpMu sync.Mutex // protects prefixRegexp
+)
+
+type handler struct {
+	prefix      string
+	options     Options
+	handlerFunc func(Session)
+	mappings    []*mapping
+
+	sessionsMux sync.Mutex
+	sessions    map[string]*session
+}
+
+// NewHandler creates new HTTP handler that conforms to the basic net/http.Handler interface.
+// It takes path prefix, options and sockjs handler function as parameters
+func NewHandler(prefix string, opts Options, handleFunc func(Session)) http.Handler {
+	return newHandler(prefix, opts, handleFunc)
+}
+
+func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler {
+	h := &handler{
+		prefix:      prefix,
+		options:     opts,
+		handlerFunc: handlerFunc,
+		sessions:    make(map[string]*session),
+	}
+
+	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
+	h.mappings = []*mapping{
+		newMapping("GET", prefix+"[/]?$", welcomeHandler),
+		newMapping("OPTIONS", prefix+"/info$", opts.cookie, xhrCors, cacheFor, opts.info),
+		newMapping("GET", prefix+"/info$", xhrCors, noCache, opts.info),
+		// XHR
+		newMapping("POST", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, noCache, h.xhrSend),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr$", opts.cookie, xhrCors, noCache, h.xhrPoll),
+		newMapping("OPTIONS", sessionPrefix+"/xhr$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, noCache, h.xhrStreaming),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		// EventStream
+		newMapping("GET", sessionPrefix+"/eventsource$", opts.cookie, xhrCors, noCache, h.eventSource),
+		// Htmlfile
+		newMapping("GET", sessionPrefix+"/htmlfile$", opts.cookie, xhrCors, noCache, h.htmlFile),
+		// JsonP
+		newMapping("GET", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, noCache, h.jsonp),
+		newMapping("OPTIONS", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/jsonp_send$", opts.cookie, xhrCors, noCache, h.jsonpSend),
+		// IFrame
+		newMapping("GET", prefix+"/iframe[0-9-.a-z_]*.html$", cacheFor, h.iframe),
+	}
+	if opts.Websocket {
+		h.mappings = append(h.mappings, newMapping("GET", sessionPrefix+"/websocket$", h.sockjsWebsocket))
+	}
+	return h
+}
+
+func (h *handler) Prefix() string { return h.prefix }
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// iterate over mappings
+	allowedMethods := []string{}
+	for _, mapping := range h.mappings {
+		if match, method := mapping.matches(req); match == fullMatch {
+			for _, hf := range mapping.chain {
+				hf(rw, req)
+			}
+			return
+		} else if match == pathMatch {
+			allowedMethods = append(allowedMethods, method)
+		}
+	}
+	if len(allowedMethods) > 0 {
+		rw.Header().Set("allow", strings.Join(allowedMethods, ", "))
+		rw.Header().Set("Content-Type", "")
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	http.NotFound(rw, req)
+}
+
+func (h *handler) parseSessionID(url *url.URL) (string, error) {
+	// cache compiled regexp objects for most used prefixes
+	prefixRegexpMu.Lock()
+	session, ok := prefixRegexp[h.prefix]
+	if !ok {
+		session = regexp.MustCompile(h.prefix + "/(?P<server>[^/.]+)/(?P<session>[^/.]+)/.*")
+		prefixRegexp[h.prefix] = session
+	}
+	prefixRegexpMu.Unlock()
+
+	matches := session.FindStringSubmatch(url.Path)
+	if len(matches) == 3 {
+		return matches[2], nil
+	}
+	return "", errors.New("unable to parse URL for session")
+}
+
+func (h *handler) sessionByRequest(req *http.Request) (*session, error) {
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		return nil, err
+	}
+	sess, exists := h.sessions[sessionID]
+	if !exists {
+		sess = newSession(sessionID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+		h.sessions[sessionID] = sess
+		if h.handlerFunc != nil {
+			go h.handlerFunc(sess)
+		}
+		go func() {
+			<-sess.closedNotify()
+			h.sessionsMux.Lock()
+			delete(h.sessions, sessionID)
+			h.sessionsMux.Unlock()
+		}()
+	}
+	return sess, nil
+}

--- a/v2/sockjs/handler_test.go
+++ b/v2/sockjs/handler_test.go
@@ -1,0 +1,79 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestHandler_Create(t *testing.T) {
+	handler := newHandler("/echo", DefaultOptions, nil)
+	if handler.Prefix() != "/echo" {
+		t.Errorf("Prefix not properly set, got '%s' expected '%s'", handler.Prefix(), "/echo")
+	}
+	if handler.sessions == nil {
+		t.Errorf("Handler session map not made")
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/echo")
+	if err != nil {
+		t.Errorf("There should not be any error, got '%s'", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestHandler_ParseSessionId(t *testing.T) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+	if session, err := h.parseSessionID(url); session != "session" || err != nil {
+		t.Errorf("Wrong session parsed, got '%s' expected '%s' with error = '%v'", session, "session", err)
+	}
+	url, _ = url.Parse("http://server:80/asdasd/server/session/whatever")
+	if _, err := h.parseSessionID(url); err == nil {
+		t.Errorf("Should return error")
+	}
+}
+
+func TestHandler_SessionByRequest(t *testing.T) {
+	h := newHandler("", DefaultOptions, nil)
+	h.options.DisconnectDelay = 10 * time.Millisecond
+	var handlerFuncCalled = make(chan Session)
+	h.handlerFunc = func(conn Session) { handlerFuncCalled <- conn }
+	req, _ := http.NewRequest("POST", "/server/sessionid/whatever/follows", nil)
+	sess, err := h.sessionByRequest(req)
+	if sess == nil || err != nil {
+		t.Errorf("Session should be returned")
+		// test handlerFunc was called
+		select {
+		case conn := <-handlerFuncCalled: // ok
+			if conn != sess {
+				t.Errorf("Handler was not passed correct session")
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("HandlerFunc was not called")
+		}
+	}
+	// test session is reused for multiple requests with same sessionID
+	req2, _ := http.NewRequest("POST", "/server/sessionid/whatever", nil)
+	if sess2, err := h.sessionByRequest(req2); sess2 != sess || err != nil {
+		t.Errorf("Expected error, got session: '%v'", sess)
+	}
+	// test session expires after timeout
+	time.Sleep(15 * time.Millisecond)
+	h.sessionsMux.Lock()
+	if _, exists := h.sessions["sessionid"]; exists {
+		t.Errorf("Session should not exist in handler after timeout")
+	}
+	h.sessionsMux.Unlock()
+	// test proper behaviour in case URL is not correct
+	req, _ = http.NewRequest("POST", "", nil)
+	if _, err := h.sessionByRequest(req); err == nil {
+		t.Errorf("Expected parser sessionID from URL error, got 'nil'")
+	}
+}

--- a/v2/sockjs/htmlfile.go
+++ b/v2/sockjs/htmlfile.go
@@ -1,0 +1,64 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var iframeTemplate = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.%s;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`
+
+var invalidCallback = regexp.MustCompile("[^a-zA-Z0-9\\_\\.]")
+
+func init() {
+	iframeTemplate += strings.Repeat(" ", 1024-len(iframeTemplate)+14)
+	iframeTemplate += "\r\n\r\n"
+}
+
+func (h *handler) htmlFile(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/html; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	} else if invalidCallback.MatchString(callback) {
+		http.Error(rw, `invalid character in "callback" parameter`, http.StatusBadRequest)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprintf(rw, iframeTemplate, callback)
+	rw.(http.Flusher).Flush()
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(htmlfileFrameWriter))
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type htmlfileFrameWriter struct{}
+
+func (*htmlfileFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "<script>\np(%s);\n</script>\r\n", quote(frame))
+}

--- a/v2/sockjs/htmlfile_test.go
+++ b/v2/sockjs/htmlfile_test.go
@@ -1,0 +1,80 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler_htmlFileNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_htmlFile(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile?c=testCallback", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+	expectedContentType := "text/html; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content-type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	if rw.Body.String() != expectedIFrame {
+		t.Errorf("Unexpected response body, got '%s', expected '%s'", rw.Body, expectedIFrame)
+	}
+
+}
+
+func TestHandler_cannotIntoXSS(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	// test simple injection
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile?c=fake%3Balert(1337)", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusBadRequest)
+	}
+
+	h = newTestHandler()
+	rw = httptest.NewRecorder()
+	// test simple injection
+	req, _ = http.NewRequest("GET", "/server/session/htmlfile?c=fake%2Dalert", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusBadRequest)
+	}
+}
+
+func init() {
+	expectedIFrame += strings.Repeat(" ", 1024-len(expectedIFrame)+len("testCallack")+13)
+	expectedIFrame += "\r\n\r\n"
+	expectedIFrame += "<script>\np(\"o\");\n</script>\r\n"
+}
+
+var expectedIFrame = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.testCallback;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`

--- a/v2/sockjs/httpreceiver.go
+++ b/v2/sockjs/httpreceiver.go
@@ -1,0 +1,105 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type frameWriter interface {
+	write(writer io.Writer, frame string) (int, error)
+}
+
+type httpReceiverState int
+
+const (
+	stateHTTPReceiverActive httpReceiverState = iota
+	stateHTTPReceiverClosed
+)
+
+type httpReceiver struct {
+	sync.Mutex
+	state httpReceiverState
+
+	frameWriter         frameWriter
+	rw                  http.ResponseWriter
+	maxResponseSize     uint32
+	currentResponseSize uint32
+	doneCh              chan struct{}
+	interruptCh         chan struct{}
+}
+
+func newHTTPReceiver(rw http.ResponseWriter, maxResponse uint32, frameWriter frameWriter) *httpReceiver {
+	recv := &httpReceiver{
+		rw:              rw,
+		frameWriter:     frameWriter,
+		maxResponseSize: maxResponse,
+		doneCh:          make(chan struct{}),
+		interruptCh:     make(chan struct{}),
+	}
+	if closeNotifier, ok := rw.(http.CloseNotifier); ok {
+		// if supported check for close notifications from http.RW
+		closeNotifyCh := closeNotifier.CloseNotify()
+		go func() {
+			select {
+			case <-closeNotifyCh:
+				recv.Lock()
+				defer recv.Unlock()
+				if recv.state < stateHTTPReceiverClosed {
+					recv.state = stateHTTPReceiverClosed
+					close(recv.interruptCh)
+				}
+			case <-recv.doneCh:
+				// ok, no action needed here, receiver closed in correct way
+				// just finish the routine
+			}
+		}()
+	}
+	return recv
+}
+
+func (recv *httpReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		recv.sendFrame(fmt.Sprintf("a[%s]",
+			strings.Join(
+				transform(messages, quote),
+				",",
+			),
+		))
+	}
+}
+
+func (recv *httpReceiver) sendFrame(value string) {
+	recv.Lock()
+	defer recv.Unlock()
+
+	if recv.state == stateHTTPReceiverActive {
+		// TODO(igm) check err, possibly act as if interrupted
+		n, _ := recv.frameWriter.write(recv.rw, value)
+		recv.currentResponseSize += uint32(n)
+		if recv.currentResponseSize >= recv.maxResponseSize {
+			recv.state = stateHTTPReceiverClosed
+			close(recv.doneCh)
+		} else {
+			recv.rw.(http.Flusher).Flush()
+		}
+	}
+}
+
+func (recv *httpReceiver) doneNotify() <-chan struct{}        { return recv.doneCh }
+func (recv *httpReceiver) interruptedNotify() <-chan struct{} { return recv.interruptCh }
+func (recv *httpReceiver) close() {
+	recv.Lock()
+	defer recv.Unlock()
+	if recv.state < stateHTTPReceiverClosed {
+		recv.state = stateHTTPReceiverClosed
+		close(recv.doneCh)
+	}
+}
+func (recv *httpReceiver) canSend() bool {
+	recv.Lock()
+	defer recv.Unlock()
+	return recv.state != stateHTTPReceiverClosed
+}

--- a/v2/sockjs/httpreceiver_test.go
+++ b/v2/sockjs/httpreceiver_test.go
@@ -1,0 +1,101 @@
+package sockjs
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+)
+
+type testFrameWriter struct {
+	frames []string
+}
+
+func (t *testFrameWriter) write(w io.Writer, frame string) (int, error) {
+	t.frames = append(t.frames, frame)
+	return len(frame), nil
+}
+
+func TestHttpReceiver_Create(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	if recv.doneCh != recv.doneNotify() {
+		t.Errorf("Calling done() must return close channel, but it does not")
+	}
+	if recv.rw != rec {
+		t.Errorf("Http.ResponseWriter not properly initialized")
+	}
+	if recv.maxResponseSize != 1024 {
+		t.Errorf("MaxResponseSize not properly initialized")
+	}
+}
+
+func TestHttpReceiver_SendEmptyFrames(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	recv.sendBulk()
+	if rec.Body.String() != "" {
+		t.Errorf("Incorrect body content received from receiver '%s'", rec.Body.String())
+	}
+}
+
+func TestHttpReceiver_SendFrame(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	var frame = "some frame content"
+	recv.sendFrame(frame)
+	if len(fw.frames) != 1 || fw.frames[0] != frame {
+		t.Errorf("Incorrect body content received, got '%s', expected '%s'", fw.frames, frame)
+	}
+
+}
+
+func TestHttpReceiver_SendBulk(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	recv.sendBulk("message 1", "message 2", "message 3")
+	expected := "a[\"message 1\",\"message 2\",\"message 3\"]"
+	if len(fw.frames) != 1 || fw.frames[0] != expected {
+		t.Errorf("Incorrect body content received from receiver, got '%s' expected '%s'", fw.frames, expected)
+	}
+}
+
+func TestHttpReceiver_MaximumResponseSize(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 52, new(testFrameWriter))
+	recv.sendBulk("message 1", "message 2") // produces 26 bytes of response in 1 frame
+	if recv.currentResponseSize != 26 {
+		t.Errorf("Incorrect response size calcualated, got '%d' expected '%d'", recv.currentResponseSize, 26)
+	}
+	select {
+	case <-recv.doneNotify():
+		t.Errorf("Receiver should not be done yet")
+	default: // ok
+	}
+	recv.sendBulk("message 1", "message 2") // produces another 26 bytes of response in 1 frame to go over max resposne size
+	select {
+	case <-recv.doneNotify(): // ok
+	default:
+		t.Errorf("Receiver closed channel did not close")
+	}
+}
+
+func TestHttpReceiver_Close(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, nil)
+	recv.close()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}
+
+func TestHttpReceiver_ConnectionInterrupt(t *testing.T) {
+	rw := newClosableRecorder()
+	recv := newHTTPReceiver(rw, 1024, nil)
+	rw.closeNotifCh <- true
+	recv.Lock()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}

--- a/v2/sockjs/iframe.go
+++ b/v2/sockjs/iframe.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+var tmpl = template.Must(template.New("iframe").Parse(iframeBody))
+
+func (h *handler) iframe(rw http.ResponseWriter, req *http.Request) {
+	etagReq := req.Header.Get("If-None-Match")
+	hash := md5.New()
+	hash.Write([]byte(iframeBody))
+	etag := fmt.Sprintf("%x", hash.Sum(nil))
+	if etag == etagReq {
+		rw.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	rw.Header().Add("ETag", etag)
+	tmpl.Execute(rw, h.options.SockJSURL)
+}
+
+var iframeBody = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="{{.}}"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/v2/sockjs/iframe_test.go
+++ b/v2/sockjs/iframe_test.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_iframe(t *testing.T) {
+	h := newTestHandler()
+	h.options.SockJSURL = "http://sockjs.com/sockjs.js"
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/sess/iframe", nil)
+	h.iframe(rw, req)
+	if rw.Body.String() != expected {
+		t.Errorf("Unexpected html content,\ngot:\n'%s'\n\nexpected\n'%s'", rw.Body, expected)
+	}
+	eTag := rw.Header().Get("etag")
+	req.Header.Set("if-none-match", eTag)
+	rw = httptest.NewRecorder()
+	h.iframe(rw, req)
+	if rw.Code != http.StatusNotModified {
+		t.Errorf("Unexpected response, got '%d', expected '%d'", rw.Code, http.StatusNotModified)
+	}
+}
+
+var expected = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="http://sockjs.com/sockjs.js"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/v2/sockjs/jsonp.go
+++ b/v2/sockjs/jsonp.go
@@ -1,0 +1,80 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (h *handler) jsonp(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	} else if invalidCallback.MatchString(callback) {
+		http.Error(rw, `invalid character in "callback" parameter`, http.StatusBadRequest)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, 1, &jsonpFrameWriter{callback})
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+func (h *handler) jsonpSend(rw http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
+	var data io.Reader
+	data = req.Body
+
+	formReader := strings.NewReader(req.PostFormValue("d"))
+	if formReader.Len() != 0 {
+		data = formReader
+	}
+	if data == nil {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(data).Decode(&messages)
+	if err == io.EOF {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if err != nil {
+		http.Error(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, _ := h.parseSessionID(req.URL)
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...) // TODO(igm) reponse with http.StatusInternalServerError in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8")
+		rw.Write([]byte("ok"))
+	}
+}
+
+type jsonpFrameWriter struct {
+	callback string
+}
+
+func (j *jsonpFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s(%s);\r\n", j.callback, quote(frame))
+}

--- a/v2/sockjs/jsonp_test.go
+++ b/v2/sockjs/jsonp_test.go
@@ -1,0 +1,106 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_jsonpNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp", nil)
+	h.jsonp(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_jsonp(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp?c=testCallback", nil)
+	h.jsonp(rw, req)
+	expectedContentType := "application/javascript; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	expectedBody := "testCallback(\"o\");\r\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s', expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_jsonpSendNoPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", nil)
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendWrongPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("wrong payload"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendNoSession(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_jsonpSend(t *testing.T) {
+	h := newTestHandler()
+	sess := newSession("session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	var done = make(chan struct{})
+	go func() {
+		h.jsonpSend(rw, req)
+		close(done)
+	}()
+	msg, _ := sess.Recv()
+	if msg != "message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rw.Code != http.StatusOK {
+		t.Errorf("Wrong response status received %d, should be %d", rw.Code, http.StatusOK)
+	}
+	if rw.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rw.Header().Get("content-type"))
+	}
+	if rw.Body.String() != "ok" {
+		t.Errorf("Unexpected body, got '%s', expected 'ok'", rw.Body)
+	}
+}
+
+func TestHandler_jsonpCannotIntoXSS(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp?c=%3Chtml%3E%3Chead%3E%3Cscript%3Ealert(5520)%3C%2Fscript%3E", nil)
+	h.jsonp(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("JsonP forwarded an exploitable response.")
+	}
+}

--- a/v2/sockjs/mapping.go
+++ b/v2/sockjs/mapping.go
@@ -1,0 +1,36 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+)
+
+type mapping struct {
+	method string
+	path   *regexp.Regexp
+	chain  []http.HandlerFunc
+}
+
+func newMapping(method string, re string, handlers ...http.HandlerFunc) *mapping {
+	return &mapping{method, regexp.MustCompile(re), handlers}
+}
+
+type matchType uint32
+
+const (
+	fullMatch matchType = iota
+	pathMatch
+	noMatch
+)
+
+// matches checks if given req.URL is a match with a mapping. Match can be either full, partial (http method mismatch) or no match.
+func (m *mapping) matches(req *http.Request) (match matchType, method string) {
+	if !m.path.MatchString(req.URL.Path) {
+		match, method = noMatch, ""
+	} else if m.method != req.Method {
+		match, method = pathMatch, m.method
+	} else {
+		match, method = fullMatch, m.method
+	}
+	return
+}

--- a/v2/sockjs/mapping_test.go
+++ b/v2/sockjs/mapping_test.go
@@ -1,0 +1,38 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+func TestMappingMatcher(t *testing.T) {
+	mappingPrefix := mapping{"GET", regexp.MustCompile("prefix/$"), nil}
+	mappingPrefixRegExp := mapping{"GET", regexp.MustCompile(".*x/$"), nil}
+
+	var testRequests = []struct {
+		mapping       mapping
+		method        string
+		url           string
+		expectedMatch matchType
+	}{
+		{mappingPrefix, "GET", "http://foo/prefix/", fullMatch},
+		{mappingPrefix, "POST", "http://foo/prefix/", pathMatch},
+		{mappingPrefix, "GET", "http://foo/prefix_not_mapped", noMatch},
+		{mappingPrefixRegExp, "GET", "http://foo/prefix/", fullMatch},
+	}
+
+	for _, request := range testRequests {
+		req, _ := http.NewRequest(request.method, request.url, nil)
+		m := request.mapping
+		match, method := m.matches(req)
+		if match != request.expectedMatch {
+			t.Errorf("mapping %s should match url=%s", m.path, request.url)
+		}
+		if request.expectedMatch == pathMatch {
+			if method != m.method {
+				t.Errorf("Matcher method should be %s, but got %s", m.method, method)
+			}
+		}
+	}
+}

--- a/v2/sockjs/options.go
+++ b/v2/sockjs/options.go
@@ -1,0 +1,114 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	entropy      *rand.Rand
+	entropyMutex sync.Mutex
+)
+
+func init() {
+	entropy = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// Options type is used for defining various sockjs options
+type Options struct {
+	// Transports which don't support cross-domain communication natively ('eventsource' to name one) use an iframe trick.
+	// A simple page is served from the SockJS server (using its foreign domain) and is placed in an invisible iframe.
+	// Code run from this iframe doesn't need to worry about cross-domain issues, as it's being run from domain local to the SockJS server.
+	// This iframe also does need to load SockJS javascript client library, and this option lets you specify its url (if you're unsure,
+	// point it to the latest minified SockJS client release, this is the default). You must explicitly specify this url on the server
+	// side for security reasons - we don't want the possibility of running any foreign javascript within the SockJS domain (aka cross site scripting attack).
+	// Also, sockjs javascript library is probably already cached by the browser - it makes sense to reuse the sockjs url you're using in normally.
+	SockJSURL string
+	// Most streaming transports save responses on the client side and don't free memory used by delivered messages.
+	// Such transports need to be garbage-collected once in a while. `response_limit` sets a minimum number of bytes that can be send
+	// over a single http streaming request before it will be closed. After that client needs to open new request.
+	// Setting this value to one effectively disables streaming and will make streaming transports to behave like polling transports.
+	// The default value is 128K.
+	ResponseLimit uint32
+	// Some load balancers don't support websockets. This option can be used to disable websockets support by the server. By default websockets are enabled.
+	Websocket bool
+	// In order to keep proxies and load balancers from closing long running http requests we need to pretend that the connection is active
+	// and send a heartbeat packet once in a while. This setting controls how often this is done.
+	// By default a heartbeat packet is sent every 25 seconds.
+	HeartbeatDelay time.Duration
+	// The server closes a session when a client receiving connection have not been seen for a while.
+	// This delay is configured by this setting.
+	// By default the session is closed when a receiving connection wasn't seen for 5 seconds.
+	DisconnectDelay time.Duration
+	// Some hosting providers enable sticky sessions only to requests that have JSessionID cookie set.
+	// This setting controls if the server should set this cookie to a dummy value.
+	// By default setting JSessionID cookie is disabled. More sophisticated behaviour can be achieved by supplying a function.
+	JSessionID func(http.ResponseWriter, *http.Request)
+}
+
+// DefaultOptions is a convenient set of options to be used for sockjs
+var DefaultOptions = Options{
+	Websocket:       true,
+	JSessionID:      nil,
+	SockJSURL:       "http://cdn.sockjs.org/sockjs-0.3.min.js",
+	HeartbeatDelay:  25 * time.Second,
+	DisconnectDelay: 5 * time.Second,
+	ResponseLimit:   128 * 1024,
+}
+
+type info struct {
+	Websocket    bool     `json:"websocket"`
+	CookieNeeded bool     `json:"cookie_needed"`
+	Origins      []string `json:"origins"`
+	Entropy      int32    `json:"entropy"`
+}
+
+func (options *Options) info(rw http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		json.NewEncoder(rw).Encode(info{
+			Websocket:    options.Websocket,
+			CookieNeeded: options.JSessionID != nil,
+			Origins:      []string{"*:*"},
+			Entropy:      generateEntropy(),
+		})
+	case "OPTIONS":
+		rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET")
+		rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+		rw.WriteHeader(http.StatusNoContent) // 204
+	default:
+		http.NotFound(rw, req)
+	}
+}
+
+// DefaultJSessionID is a default behaviour function to be used in options for JSessionID if JSESSIONID is needed
+func DefaultJSessionID(rw http.ResponseWriter, req *http.Request) {
+	cookie, err := req.Cookie("JSESSIONID")
+	if err == http.ErrNoCookie {
+		cookie = &http.Cookie{
+			Name:  "JSESSIONID",
+			Value: "dummy",
+		}
+	}
+	cookie.Path = "/"
+	header := rw.Header()
+	header.Add("Set-Cookie", cookie.String())
+}
+
+func (options *Options) cookie(rw http.ResponseWriter, req *http.Request) {
+	if options.JSessionID != nil { // cookie is needed
+		options.JSessionID(rw, req)
+	}
+}
+
+func generateEntropy() int32 {
+	entropyMutex.Lock()
+	entropy := entropy.Int31()
+	entropyMutex.Unlock()
+	return entropy
+}

--- a/v2/sockjs/options_test.go
+++ b/v2/sockjs/options_test.go
@@ -1,0 +1,64 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+)
+import "testing"
+
+func TestInfoGet(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "", nil)
+	DefaultOptions.info(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Wrong status code, got '%d' expected '%d'", recorder.Code, http.StatusOK)
+	}
+
+	decoder := json.NewDecoder(recorder.Body)
+	var a info
+	decoder.Decode(&a)
+	if !a.Websocket {
+		t.Errorf("Websocket field should be set true")
+	}
+	if a.CookieNeeded {
+		t.Errorf("CookieNeede should be set to false")
+	}
+}
+
+func TestInfoOptions(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("OPTIONS", "", nil)
+	DefaultOptions.info(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("Incorrect status code received, got '%d' expected '%d'", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestInfoUnknown(t *testing.T) {
+	req, _ := http.NewRequest("PUT", "", nil)
+	rec := httptest.NewRecorder()
+	DefaultOptions.info(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Incorrec response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "", nil)
+	optionsWithCookies := DefaultOptions
+	optionsWithCookies.JSessionID = DefaultJSessionID
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=dummy; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+	// cookie value set in request
+	req.AddCookie(&http.Cookie{Name: "JSESSIONID", Value: "some_jsession_id", Path: "/"})
+	rec = httptest.NewRecorder()
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=some_jsession_id; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+}

--- a/v2/sockjs/session.go
+++ b/v2/sockjs/session.go
@@ -1,0 +1,219 @@
+package sockjs
+
+import (
+	"encoding/gob"
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+type sessionState uint32
+
+const (
+	// brand new session, need to send "h" to receiver
+	sessionOpening sessionState = iota
+	// active session
+	sessionActive
+	// session being closed, sending "closeFrame" to receivers
+	sessionClosing
+	// closed session, no activity at all, should be removed from handler completely and not reused
+	sessionClosed
+)
+
+var (
+	// ErrSessionNotOpen error is used to denote session not in open state.
+	// Recv() and Send() operations are not suppored if session is closed.
+	ErrSessionNotOpen          = errors.New("sockjs: session not in open state")
+	errSessionReceiverAttached = errors.New("sockjs: another receiver already attached")
+)
+
+type session struct {
+	sync.Mutex
+	id    string
+	state sessionState
+	// protocol dependent receiver (xhr, eventsource, ...)
+	recv receiver
+	// messages to be sent to client
+	sendBuffer []string
+	// messages received from client to be consumed by application
+	// receivedBuffer chan string
+	msgReader  *io.PipeReader
+	msgWriter  *io.PipeWriter
+	msgEncoder *gob.Encoder
+	msgDecoder *gob.Decoder
+
+	// closeFrame to send after session is closed
+	closeFrame string
+
+	// internal timer used to handle session expiration if no receiver is attached, or heartbeats if recevier is attached
+	sessionTimeoutInterval time.Duration
+	heartbeatInterval      time.Duration
+	timer                  *time.Timer
+	// once the session timeouts this channel also closes
+	closeCh chan struct{}
+}
+
+type receiver interface {
+	// sendBulk send multiple data messages in frame frame in format: a["msg 1", "msg 2", ....]
+	sendBulk(...string)
+	// sendFrame sends given frame over the wire (with possible chunking depending on receiver)
+	sendFrame(string)
+	// close closes the receiver in a "done" way (idempotent)
+	close()
+	canSend() bool
+	// done notification channel gets closed whenever receiver ends
+	doneNotify() <-chan struct{}
+	// interrupted channel gets closed whenever receiver is interrupted (i.e. http connection drops,...)
+	interruptedNotify() <-chan struct{}
+}
+
+// Session is a central component that handles receiving and sending frames. It maintains internal state
+func newSession(sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration) *session {
+	r, w := io.Pipe()
+	s := &session{
+		id:                     sessionID,
+		msgReader:              r,
+		msgWriter:              w,
+		msgEncoder:             gob.NewEncoder(w),
+		msgDecoder:             gob.NewDecoder(r),
+		sessionTimeoutInterval: sessionTimeoutInterval,
+		heartbeatInterval:      heartbeatInterval,
+		closeCh:                make(chan struct{})}
+	s.Lock() // "go test -race" complains if ommited, not sure why as no race can happen here
+	s.timer = time.AfterFunc(sessionTimeoutInterval, s.close)
+	s.Unlock()
+	return s
+}
+
+func (s *session) sendMessage(msg string) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.state > sessionActive {
+		return ErrSessionNotOpen
+	}
+	s.sendBuffer = append(s.sendBuffer, msg)
+	if s.recv != nil && s.recv.canSend() {
+		s.recv.sendBulk(s.sendBuffer...)
+		s.sendBuffer = nil
+	}
+	return nil
+}
+
+func (s *session) attachReceiver(recv receiver) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil {
+		return errSessionReceiverAttached
+	}
+	s.recv = recv
+	go func(r receiver) {
+		select {
+		case <-r.doneNotify():
+			s.detachReceiver()
+		case <-r.interruptedNotify():
+			s.detachReceiver()
+			s.close()
+		}
+	}(recv)
+
+	if s.state == sessionClosing {
+		s.recv.sendFrame(s.closeFrame)
+		s.recv.close()
+		return nil
+	}
+	if s.state == sessionOpening {
+		s.recv.sendFrame("o")
+		s.state = sessionActive
+	}
+	s.recv.sendBulk(s.sendBuffer...)
+	s.sendBuffer = nil
+	s.timer.Stop()
+	if s.heartbeatInterval > 0 {
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+	return nil
+}
+
+func (s *session) detachReceiver() {
+	s.Lock()
+	defer s.Unlock()
+	s.timer.Stop()
+	s.timer = time.AfterFunc(s.sessionTimeoutInterval, s.close)
+	s.recv = nil
+}
+
+func (s *session) heartbeat() {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil { // timer could have fired between Lock and timer.Stop in detachReceiver
+		s.recv.sendFrame("h")
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+}
+
+func (s *session) accept(messages ...string) error {
+	for _, msg := range messages {
+		if err := s.msgEncoder.Encode(msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// idempotent operation
+func (s *session) closing() {
+	s.Lock()
+	defer s.Unlock()
+	if s.state < sessionClosing {
+		s.msgReader.Close()
+		s.msgWriter.Close()
+		s.state = sessionClosing
+		if s.recv != nil {
+			s.recv.sendFrame(s.closeFrame)
+			s.recv.close()
+		}
+	}
+}
+
+// idempotent operation
+func (s *session) close() {
+	s.closing()
+	s.Lock()
+	defer s.Unlock()
+	if s.state < sessionClosed {
+		s.state = sessionClosed
+		s.timer.Stop()
+		close(s.closeCh)
+	}
+}
+
+func (s *session) closedNotify() <-chan struct{} { return s.closeCh }
+
+// Conn interface implementation
+func (s *session) Close(status uint32, reason string) error {
+	s.Lock()
+	if s.state < sessionClosing {
+		s.closeFrame = closeFrame(status, reason)
+		s.Unlock()
+		s.closing()
+		return nil
+	}
+	s.Unlock()
+	return ErrSessionNotOpen
+}
+
+func (s *session) Recv() (string, error) {
+	var msg string
+	err := s.msgDecoder.Decode(&msg)
+	if err == io.ErrClosedPipe {
+		err = ErrSessionNotOpen
+	}
+	return msg, err
+}
+
+func (s *session) Send(msg string) error {
+	return s.sendMessage(msg)
+}
+
+func (s *session) ID() string { return s.id }

--- a/v2/sockjs/session_test.go
+++ b/v2/sockjs/session_test.go
@@ -1,0 +1,327 @@
+package sockjs
+
+import (
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestSession() *session {
+	// session with long expiration and heartbeats with ID
+	return newSession("sessionId", 1000*time.Second, 1000*time.Second)
+}
+
+func TestSession_Create(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("this is a message")
+	if len(session.sendBuffer) != 1 {
+		t.Errorf("Session send buffer should contain 1 message")
+	}
+	session.sendMessage("another message")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("Session send buffer should contain 2 messages")
+	}
+	if session.state != sessionOpening {
+		t.Errorf("Session in wrong state %v, should be %v", session.state, sessionOpening)
+	}
+}
+
+func TestSession_ConcurrentSend(t *testing.T) {
+	session := newTestSession()
+	done := make(chan bool)
+	for i := 0; i < 100; i++ {
+		go func() {
+			session.sendMessage("message D")
+			done <- true
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	if len(session.sendBuffer) != 100 {
+		t.Errorf("Session send buffer should contain 102 messages")
+	}
+}
+
+func TestSession_AttachReceiver(t *testing.T) {
+	session := newTestSession()
+	recv := &testReceiver{}
+	// recv := &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		if frame != "o" {
+	// 			t.Errorf("Incorrect open header received")
+	// 		}
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+	if session.state != sessionActive {
+		t.Errorf("Session in wrong state after receiver attached %d, should be %d", session.state, sessionActive)
+	}
+	session.detachReceiver()
+	// recv = &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		t.Errorf("No frame shold be send, got '%s'", frame)
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+}
+
+func TestSession_Timeout(t *testing.T) {
+	sess := newSession("id", 10*time.Millisecond, 10*time.Second)
+	select {
+	case <-sess.closeCh:
+	case <-time.After(20 * time.Millisecond):
+		t.Errorf("sess close notification channel should close")
+	}
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session did not timeout")
+	}
+	sess.Unlock()
+}
+
+func TestSession_TimeoutOfClosedSession(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	sess := newSession("id", 1*time.Millisecond, time.Second)
+	sess.closing()
+	time.Sleep(1 * time.Millisecond)
+	sess.closing()
+}
+
+func TestSession_AttachReceiverAndCheckHeartbeats(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	session := newSession("id", time.Second, 10*time.Millisecond) // 10ms heartbeats
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+	session.attachReceiver(recv)
+	time.Sleep(120 * time.Millisecond)
+	recv.Lock()
+	if len(recv.frames) < 10 || len(recv.frames) > 13 { // should get around 10 heartbeats (120ms/10ms)
+		t.Fatalf("Wrong number of frames received, got '%d'", len(recv.frames))
+	}
+	for i := 1; i < len(recv.frames); i++ {
+		if recv.frames[i] != "h" {
+			t.Errorf("Heartbeat no received")
+		}
+	}
+}
+
+func TestSession_AttachReceiverAndRefuse(t *testing.T) {
+	session := newTestSession()
+	if err := session.attachReceiver(newTestReceiver()); err != nil {
+		t.Errorf("Should not return error")
+	}
+	var a sync.WaitGroup
+	a.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer a.Done()
+			if err := session.attachReceiver(newTestReceiver()); err != errSessionReceiverAttached {
+				t.Errorf("Should return error as another receiver is already attached")
+			}
+		}()
+	}
+	a.Wait()
+}
+
+func TestSession_DetachRecevier(t *testing.T) {
+	session := newTestSession()
+	session.detachReceiver()
+	session.detachReceiver() // idempotent operation
+	session.attachReceiver(newTestReceiver())
+	session.detachReceiver()
+
+}
+
+func TestSession_SendWithRecv(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("message A")
+	session.sendMessage("message B")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("There should be 2 messages in buffer, but there are %d", len(session.sendBuffer))
+	}
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+
+	session.attachReceiver(recv)
+	if len(recv.frames[1:]) != 2 {
+		t.Errorf("Reciver should get 2 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message C")
+	if len(recv.frames[1:]) != 3 {
+		t.Errorf("Reciver should get 3 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message D")
+	if len(recv.frames[1:]) != 4 {
+		t.Errorf("Reciver should get 4 frames from session, got %d", len(recv.frames))
+	}
+	if len(session.sendBuffer) != 0 {
+		t.Errorf("Send buffer should be empty now, but there are %d messaged", len(session.sendBuffer))
+	}
+}
+
+func TestSession_Recv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic should not happen")
+		}
+	}()
+	session := newTestSession()
+	go func() {
+		session.accept("message A")
+		session.accept("message B")
+		if err := session.accept("message C"); err != io.ErrClosedPipe {
+			t.Errorf("Session should not accept new messages if closed, got '%v' expected '%v'", err, io.ErrClosedPipe)
+		}
+	}()
+	if msg, _ := session.Recv(); msg != "message A" {
+		t.Errorf("Got %s, should be %s", msg, "message A")
+	}
+	if msg, _ := session.Recv(); msg != "message B" {
+		t.Errorf("Got %s, should be %s", msg, "message B")
+	}
+	session.close()
+}
+
+func TestSession_Closing(t *testing.T) {
+	session := newTestSession()
+	session.closing()
+	if _, err := session.Recv(); err == nil {
+		t.Errorf("Session's receive buffer channel should close")
+	}
+	if err := session.sendMessage("some message"); err != ErrSessionNotOpen {
+		t.Errorf("Session should not accept new message after close")
+	}
+}
+
+// Session as Session Tests
+func TestSession_AsSession(t *testing.T) { var _ Session = newSession("id", 0, 0) }
+
+func TestSession_SessionRecv(t *testing.T) {
+	s := newTestSession()
+	go func() {
+		s.accept("message 1")
+	}()
+	msg, err := s.Recv()
+	if msg != "message 1" || err != nil {
+		t.Errorf("Should receive a message without error, got '%s' err '%v'", msg, err)
+	}
+	go func() {
+		s.closing()
+		_, err := s.Recv()
+		if err != ErrSessionNotOpen {
+			t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+		}
+	}()
+	_, err = s.Recv()
+	if err != ErrSessionNotOpen {
+		t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+	}
+}
+
+func TestSession_SessionSend(t *testing.T) {
+	s := newTestSession()
+	err := s.Send("message A")
+	if err != nil {
+		t.Errorf("Session should take messages by default")
+	}
+	if len(s.sendBuffer) != 1 || s.sendBuffer[0] != "message A" {
+		t.Errorf("Message not properly queued in session, got '%v'", s.sendBuffer)
+	}
+}
+
+func TestSession_SessionClose(t *testing.T) {
+	s := newTestSession()
+	s.state = sessionActive
+	recv := newTestReceiver()
+	s.attachReceiver(recv)
+	err := s.Close(1, "some reason")
+	if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+		t.Errorf("Expected close frame, got '%v'", recv.frames)
+	}
+	if err != nil {
+		t.Errorf("Should not get any error, got '%s'", err)
+	}
+	if s.closeFrame != "c[1,\"some reason\"]" {
+		t.Errorf("Incorrect closeFrame, got '%s'", s.closeFrame)
+	}
+	if s.state != sessionClosing {
+		t.Errorf("Incorrect session state, expected 'sessionClosing', got '%v'", s.state)
+	}
+	// all the consequent receivers trying to attach shoult get the same close frame
+	var i = 100
+	for i > 0 {
+		recv := newTestReceiver()
+		err := s.attachReceiver(recv)
+		if err != nil {
+			// give a chance to a receiver to detach
+			runtime.Gosched()
+			continue
+		}
+		i--
+		if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+			t.Errorf("Close frame not received by recv, frames '%v'", recv.frames)
+		}
+	}
+	if err := s.Close(1, "some other reson"); err != ErrSessionNotOpen {
+		t.Errorf("Expected error, got '%v'", err)
+	}
+}
+
+func TestSession_SessionSessionId(t *testing.T) {
+	s := newTestSession()
+	if s.ID() != "sessionId" {
+		t.Errorf("Unexpected session ID, got '%s', expected '%s'", s.ID(), "sessionId")
+	}
+}
+
+func newTestReceiver() *testReceiver {
+	return &testReceiver{
+		doneCh:      make(chan struct{}),
+		interruptCh: make(chan struct{}),
+	}
+}
+
+type testReceiver struct {
+	sync.Mutex
+	doneCh, interruptCh chan struct{}
+	frames              []string
+}
+
+func (t *testReceiver) doneNotify() <-chan struct{}        { return t.doneCh }
+func (t *testReceiver) interruptedNotify() <-chan struct{} { return t.interruptCh }
+func (t *testReceiver) close()                             { close(t.doneCh) }
+func (t *testReceiver) canSend() bool {
+	select {
+	case <-t.doneCh:
+		return false // already closed
+	default:
+		return true
+	}
+}
+func (t *testReceiver) sendBulk(messages ...string) {
+	for _, m := range messages {
+		t.sendFrame(m)
+	}
+}
+func (t *testReceiver) sendFrame(frame string) {
+	t.Lock()
+	defer t.Unlock()
+	t.frames = append(t.frames, frame)
+}

--- a/v2/sockjs/sockjs.go
+++ b/v2/sockjs/sockjs.go
@@ -1,0 +1,13 @@
+package sockjs
+
+// Session represents a connection between server and client.
+type Session interface {
+	// Id returns a session id
+	ID() string
+	// Recv reads one text frame from session
+	Recv() (string, error)
+	// Send sends one text frame to session
+	Send(string) error
+	// Close closes the session with provided code and reason.
+	Close(status uint32, reason string) error
+}

--- a/v2/sockjs/sockjs_test.go
+++ b/v2/sockjs/sockjs_test.go
@@ -1,0 +1,27 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func TestSockJS_ServeHTTP(t *testing.T) {
+	m := handler{mappings: make([]*mapping, 0)}
+	m.mappings = []*mapping{
+		&mapping{"POST", regexp.MustCompile("/foo/.*"), []http.HandlerFunc{func(http.ResponseWriter, *http.Request) {}}},
+	}
+	req, _ := http.NewRequest("GET", "/foo/bar", nil)
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusMethodNotAllowed)
+	}
+	req, _ = http.NewRequest("GET", "/bar", nil)
+	rec = httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}

--- a/v2/sockjs/utils.go
+++ b/v2/sockjs/utils.go
@@ -1,0 +1,16 @@
+package sockjs
+
+import "encoding/json"
+
+func quote(in string) string {
+	quoted, _ := json.Marshal(in)
+	return string(quoted)
+}
+
+func transform(values []string, transformFn func(string) string) []string {
+	ret := make([]string, len(values))
+	for i, msg := range values {
+		ret[i] = transformFn(msg)
+	}
+	return ret
+}

--- a/v2/sockjs/utils_test.go
+++ b/v2/sockjs/utils_test.go
@@ -1,0 +1,19 @@
+package sockjs
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	var quotationTests = []struct {
+		input  string
+		output string
+	}{
+		{"simple", "\"simple\""},
+		{"more complex \"", "\"more complex \\\"\""},
+	}
+
+	for _, testCase := range quotationTests {
+		if quote(testCase.input) != testCase.output {
+			t.Errorf("Expected '%s', got '%s'", testCase.output, quote(testCase.input))
+		}
+	}
+}

--- a/v2/sockjs/web.go
+++ b/v2/sockjs/web.go
@@ -1,0 +1,47 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func xhrCors(rw http.ResponseWriter, req *http.Request) {
+	header := rw.Header()
+	origin := req.Header.Get("origin")
+	if origin == "" || origin == "null" {
+		origin = "*"
+	}
+	header.Set("Access-Control-Allow-Origin", origin)
+
+	if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
+		header.Add("Access-Control-Allow-Headers", allowHeaders)
+	}
+	header.Add("Access-Control-Allow-Credentials", "true")
+}
+
+func xhrOptions(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+	rw.WriteHeader(http.StatusNoContent) // 204
+}
+
+func cacheFor(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", 365*24*60*60))
+	rw.Header().Set("Expires", time.Now().AddDate(1, 0, 0).Format(time.RFC1123))
+	rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+}
+
+func noCache(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+}
+
+func welcomeHandler(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/plain;charset=UTF-8")
+	fmt.Fprintf(rw, "Welcome to SockJS!\n")
+}
+
+func httpError(w http.ResponseWriter, error string, code int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(code)
+	fmt.Fprintf(w, error)
+}

--- a/v2/sockjs/web_test.go
+++ b/v2/sockjs/web_test.go
@@ -1,0 +1,69 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestXhrCors(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "*" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "*")
+	}
+	req.Header.Set("origin", "localhost")
+	xhrCors(recorder, req)
+	acao = recorder.Header().Get("access-control-allow-origin")
+	if acao != "localhost" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "localhost")
+	}
+
+	req.Header.Set("access-control-request-headers", "some value")
+	rec := httptest.NewRecorder()
+	xhrCors(rec, req)
+	if rec.Header().Get("access-control-allow-headers") != "some value" {
+		t.Errorf("Incorent value for ACAH, got %s", rec.Header().Get("access-control-allow-headers"))
+	}
+}
+
+func TestXhrOptions(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrOptions(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status code, expected %d, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestCacheFor(t *testing.T) {
+	rec := httptest.NewRecorder()
+	cacheFor(rec, nil)
+	cacheControl := rec.Header().Get("cache-control")
+	if cacheControl != "public, max-age=31536000" {
+		t.Errorf("Incorrect cache-control header value, got '%s'", cacheControl)
+	}
+	expires := rec.Header().Get("expires")
+	if expires == "" {
+		t.Errorf("Expires header should not be empty") // TODO(igm) check proper formating of string
+	}
+	maxAge := rec.Header().Get("access-control-max-age")
+	if maxAge != "31536000" {
+		t.Errorf("Incorrect value for access-control-max-age, got '%s'", maxAge)
+	}
+}
+
+func TestNoCache(t *testing.T) {
+	rec := httptest.NewRecorder()
+	noCache(rec, nil)
+}
+
+func TestWelcomeHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	welcomeHandler(rec, nil)
+	if rec.Body.String() != "Welcome to SockJS!\n" {
+		t.Errorf("Incorrect welcome message received, got '%s'", rec.Body.String())
+	}
+}

--- a/v2/sockjs/websocket.go
+++ b/v2/sockjs/websocket.go
@@ -1,0 +1,97 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// WebSocketReadBufSize is a parameter that is used for WebSocket Upgrader.
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketReadBufSize = 4096
+
+// WebSocketWriteBufSize is a parameter that is used for WebSocket Upgrader
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketWriteBufSize = 4096
+
+func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
+	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	if _, ok := err.(websocket.HandshakeError); ok {
+		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
+		return
+	} else if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	sessID, _ := h.parseSessionID(req.URL)
+	sess := newSession(sessID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+	if h.handlerFunc != nil {
+		go h.handlerFunc(sess)
+	}
+
+	receiver := newWsReceiver(conn)
+	sess.attachReceiver(receiver)
+	readCloseCh := make(chan struct{})
+	go func() {
+		var d []string
+		for {
+			err := conn.ReadJSON(&d)
+			if err != nil {
+				close(readCloseCh)
+				return
+			}
+			sess.accept(d...)
+		}
+	}()
+
+	select {
+	case <-readCloseCh:
+	case <-receiver.doneNotify():
+	}
+	sess.close()
+	conn.Close()
+}
+
+type wsReceiver struct {
+	conn    *websocket.Conn
+	closeCh chan struct{}
+}
+
+func newWsReceiver(conn *websocket.Conn) *wsReceiver {
+	return &wsReceiver{
+		conn:    conn,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (w *wsReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		w.sendFrame(fmt.Sprintf("a[%s]", strings.Join(transform(messages, quote), ",")))
+	}
+}
+
+func (w *wsReceiver) sendFrame(frame string) {
+	if err := w.conn.WriteMessage(websocket.TextMessage, []byte(frame)); err != nil {
+		w.close()
+	}
+}
+
+func (w *wsReceiver) close() {
+	select {
+	case <-w.closeCh: // already closed
+	default:
+		close(w.closeCh)
+	}
+}
+func (w *wsReceiver) canSend() bool {
+	select {
+	case <-w.closeCh: // already closed
+		return false
+	default:
+		return true
+	}
+}
+func (w *wsReceiver) doneNotify() <-chan struct{}        { return w.closeCh }
+func (w *wsReceiver) interruptedNotify() <-chan struct{} { return nil }

--- a/v2/sockjs/websocket_test.go
+++ b/v2/sockjs/websocket_test.go
@@ -1,0 +1,119 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestHandler_WebSocketHandshakeError(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("origin", "https"+server.URL[4:])
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestHandler_WebSocket(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var connCh = make(chan Session)
+	h.handlerFunc = func(conn Session) { connCh <- conn }
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if conn == nil {
+		t.Errorf("Connection should not be nil")
+	}
+	if err != nil {
+		t.Errorf("Unexpected error '%v'", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("Wrong response code returned, got '%d', expected '%d'", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-connCh: //ok
+	case <-time.After(10 * time.Millisecond):
+		t.Errorf("Sockjs Handler not invoked")
+	}
+}
+
+func TestHandler_WebSocketTerminationByServer(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	h.handlerFunc = func(conn Session) {
+		conn.Close(1024, "some close message")
+		conn.Close(0, "this should be ignored")
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	_, msg, err := conn.ReadMessage()
+	if string(msg) != "o" || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, "o")
+	}
+	_, msg, err = conn.ReadMessage()
+	if string(msg) != `c[1024,"some close message"]` || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, `c[1024,"some close message"]`)
+	}
+	_, msg, err = conn.ReadMessage()
+	// gorilla websocket keeps `errUnexpectedEOF` private so we need to introspect the error message
+	if err != nil {
+		if !strings.Contains(err.Error(), "unexpected EOF") {
+			t.Errorf("Expected 'unexpected EOF' error or similar, got '%v'", err)
+		}
+	}
+}
+
+func TestHandler_WebSocketTerminationByClient(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		if _, err := conn.Recv(); err != ErrSessionNotOpen {
+			t.Errorf("Recv should fail")
+		}
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.Close()
+	<-done
+}
+
+func TestHandler_WebSocketCommunication(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	// defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		conn.Send("message 1")
+		conn.Send("message 2")
+		msg, err := conn.Recv()
+		if msg != "message 3" || err != nil {
+			t.Errorf("Got '%s', expecte '%s'", msg, "message 3")
+		}
+		conn.Close(123, "close")
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.WriteJSON([]string{"message 3"})
+	var expected = []string{"o", `a["message 1"]`, `a["message 2"]`, `c[123,"close"]`}
+	for _, exp := range expected {
+		_, msg, err := conn.ReadMessage()
+		if string(msg) != exp || err != nil {
+			t.Errorf("Wrong frame, got '%s' and error '%v', expected '%s' without error", msg, err, exp)
+		}
+	}
+	<-done
+}

--- a/v2/sockjs/xhr.go
+++ b/v2/sockjs/xhr.go
@@ -1,0 +1,88 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var (
+	cFrame              = closeFrame(2010, "Another connection still open")
+	xhrStreamingPrelude = strings.Repeat("h", 2048)
+)
+
+func (h *handler) xhrSend(rw http.ResponseWriter, req *http.Request) {
+	if req.Body == nil {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(req.Body).Decode(&messages)
+	if err == io.EOF {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if _, ok := err.(*json.SyntaxError); ok || err == io.ErrUnexpectedEOF {
+		httpError(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...)                                 // TODO(igm) reponse with SISE in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8") // Ignored by net/http (but protocol test complains), see https://code.google.com/p/go/source/detail?r=902dc062bff8
+		rw.WriteHeader(http.StatusNoContent)
+	}
+}
+
+type xhrFrameWriter struct{}
+
+func (*xhrFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s\n", frame)
+}
+
+func (h *handler) xhrPoll(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	sess, _ := h.sessionByRequest(req) // TODO(igm) add err handling, although err should not happen as handler should not pass req in that case
+	receiver := newHTTPReceiver(rw, 1, new(xhrFrameWriter))
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}
+
+func (h *handler) xhrStreaming(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	fmt.Fprintf(rw, "%s\n", xhrStreamingPrelude)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	receiver := newHTTPReceiver(rw, h.options.ResponseLimit, new(xhrFrameWriter))
+
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}

--- a/v2/sockjs/xhr_test.go
+++ b/v2/sockjs/xhr_test.go
@@ -1,0 +1,185 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_XhrSendNilBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", nil)
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendEmptyBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", strings.NewReader(""))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendWrongUrlPath(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "incorrect", strings.NewReader("[\"a\"]"))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexcpected response status, got '%d', expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendToExistingSession(t *testing.T) {
+	h := newTestHandler()
+	sess := newSession("session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	var done = make(chan bool)
+	go func() {
+		h.xhrSend(rec, req)
+		done <- true
+	}()
+	msg, _ := sess.Recv()
+	if msg != "some message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status received %d, should be %d", rec.Code, http.StatusNoContent)
+	}
+	if rec.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rec.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrSendInvalidInput(t *testing.T) {
+	h := newTestHandler()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("some invalid message frame"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+
+	// unexpected EOF
+	req, _ = http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"x"))
+	rec = httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendSessionNotFound(t *testing.T) {
+	h := handler{}
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_XhrPoll(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	h.xhrPoll(rw, req)
+	if rw.Header().Get("content-type") != "application/javascript; charset=UTF-8" {
+		t.Errorf("Wrong content type received, got '%s'", rw.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrPollConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = sessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.xhrPoll(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}
+
+func TestHandler_XhrPollAnotherConnectionExists(t *testing.T) {
+	h := newTestHandler()
+	// turn of timeoutes and heartbeats
+	sess := newSession("session", time.Hour, time.Hour)
+	h.sessions["session"] = sess
+	sess.attachReceiver(newTestReceiver())
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	rw2 := httptest.NewRecorder()
+	h.xhrPoll(rw2, req)
+	if rw2.Body.String() != "c[2010,\"Another connection still open\"]\n" {
+		t.Errorf("Unexpected body, got '%s'", rw2.Body)
+	}
+}
+
+func TestHandler_XhrStreaming(t *testing.T) {
+	h := newTestHandler()
+	rw := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	h.xhrStreaming(rw, req)
+	expectedBody := strings.Repeat("h", 2048) + "\no\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s' expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_XhrStreamingAnotherReceiver(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 4096
+	rw1 := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	go func() {
+		rec := httptest.NewRecorder()
+		h.xhrStreaming(rec, req)
+		expectedBody := strings.Repeat("h", 2048) + "\n" + "c[2010,\"Another connection still open\"]\n"
+		if rec.Body.String() != expectedBody {
+			t.Errorf("Unexpected body got '%s', expected '%s', ", rec.Body, expectedBody)
+		}
+		close(rw1.closeNotifCh)
+	}()
+	h.xhrStreaming(rw1, req)
+}
+
+// various test only structs
+func newTestHandler() *handler {
+	h := &handler{sessions: make(map[string]*session)}
+	h.options.HeartbeatDelay = time.Hour
+	h.options.DisconnectDelay = time.Hour
+	return h
+}
+
+type ClosableRecorder struct {
+	*httptest.ResponseRecorder
+	closeNotifCh chan bool
+}
+
+func newClosableRecorder() *ClosableRecorder {
+	return &ClosableRecorder{httptest.NewRecorder(), make(chan bool)}
+}
+
+func (cr *ClosableRecorder) CloseNotify() <-chan bool { return cr.closeNotifCh }

--- a/v2/testserver/server.go
+++ b/v2/testserver/server.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/igm/sockjs-go/v2/sockjs"
+	"golang.org/x/net/websocket"
+)
+
+type testHandler struct {
+	prefix  string
+	handler http.Handler
+}
+
+func newSockjsHandler(prefix string, options sockjs.Options, fn func(sockjs.Session)) *testHandler {
+	return &testHandler{prefix, sockjs.NewHandler(prefix, options, fn)}
+}
+
+type testHandlers []*testHandler
+
+func main() {
+	// prepare various options for tests
+	echoOptions := sockjs.DefaultOptions
+	echoOptions.ResponseLimit = 4096
+
+	disabledWebsocketOptions := sockjs.DefaultOptions
+	disabledWebsocketOptions.Websocket = false
+
+	cookieNeededOptions := sockjs.DefaultOptions
+	cookieNeededOptions.JSessionID = sockjs.DefaultJSessionID
+	// register various test handlers
+	var handlers = []*testHandler{
+		&testHandler{"/echo/websocket", websocket.Handler(echoWsHandler)},
+		&testHandler{"/close/websocket", websocket.Handler(closeWsHandler)},
+		newSockjsHandler("/echo", echoOptions, echoHandler),
+		newSockjsHandler("/echo", echoOptions, echoHandler),
+		newSockjsHandler("/cookie_needed_echo", cookieNeededOptions, echoHandler),
+		newSockjsHandler("/close", sockjs.DefaultOptions, closeHandler),
+		newSockjsHandler("/disabled_websocket_echo", disabledWebsocketOptions, echoHandler),
+	}
+	log.Fatal(http.ListenAndServe(":8081", testHandlers(handlers)))
+}
+
+func (t testHandlers) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	for _, handler := range t {
+		if strings.HasPrefix(req.URL.Path, handler.prefix) {
+			handler.handler.ServeHTTP(rw, req)
+			return
+		}
+	}
+	http.NotFound(rw, req)
+}
+
+func closeWsHandler(ws *websocket.Conn) { ws.Close() }
+func echoWsHandler(ws *websocket.Conn)  { io.Copy(ws, ws) }
+
+func closeHandler(conn sockjs.Session) { conn.Close(3000, "Go away!") }
+func echoHandler(conn sockjs.Session) {
+	log.Println("New connection created")
+	for {
+		if msg, err := conn.Recv(); err != nil {
+			break
+		} else {
+			if err := conn.Send(msg); err != nil {
+				break
+			}
+		}
+	}
+	log.Println("Sessionection closed")
+}


### PR DESCRIPTION
This PR creates a new `v2` subdirectory with the content of branch `v2` with addition of `go.mod`. Once merged into `master` the library can be used by importing v2 as `github.com/igm/sockjs-go/v2/sockjs`.

As the content matches exactly of branch `v2` existing import path:

```gopkg.in/igm/sockjs-go.v2/sockjs```

can be safely replaced by: 

```github.com/igm/sockjs-go/v2/sockjs```

the PR is backwards compatible and contributes to: https://github.com/igm/sockjs-go/issues/61 