### PR TITLE
Changed Session form alias to struct to enable better godoc generation

### DIFF
--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,8 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/v3/sockjs/benchmarks_test.go
+++ b/v3/sockjs/benchmarks_test.go
@@ -18,7 +18,7 @@ import (
 
 func BenchmarkSimple(b *testing.B) {
 	var messages = make(chan string, 10)
-	h := NewHandler("/echo", DefaultOptions, func(session *session) {
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
 		for m := range messages {
 			_ = session.Send(m)
 		}
@@ -42,7 +42,7 @@ func BenchmarkSimple(b *testing.B) {
 
 func BenchmarkMessages(b *testing.B) {
 	msg := strings.Repeat("m", 10)
-	h := NewHandler("/echo", DefaultOptions, func(session *session) {
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
 		for n := 0; n < b.N; n++ {
 			_ = session.Send(msg)
 		}
@@ -101,7 +101,7 @@ func BenchmarkMessageWebsocket(b *testing.B) {
 		ResponseLimit:   uint32(*size),
 	}
 
-	h := NewHandler("/echo", opts, func(session *session) {
+	h := NewHandler("/echo", opts, func(session Session) {
 		for {
 			msg, err := session.Recv()
 			if err != nil {

--- a/v3/sockjs/eventsource.go
+++ b/v3/sockjs/eventsource.go
@@ -25,7 +25,7 @@ func (h *Handler) eventSource(rw http.ResponseWriter, req *http.Request) {
 		recv.close()
 		return
 	}
-	sess.startHandlerOnce.Do(func() { go h.handlerFunc(sess) })
+	sess.startHandlerOnce.Do(func() { go h.handlerFunc(Session{sess}) })
 	select {
 	case <-recv.doneNotify():
 	case <-recv.interruptedNotify():

--- a/v3/sockjs/handler.go
+++ b/v3/sockjs/handler.go
@@ -11,7 +11,7 @@ import (
 type Handler struct {
 	prefix      string
 	options     Options
-	handlerFunc func(*session)
+	handlerFunc func(Session)
 	mappings    []*mapping
 
 	sessionsMux sync.Mutex

--- a/v3/sockjs/handler_test.go
+++ b/v3/sockjs/handler_test.go
@@ -88,8 +88,8 @@ func TestHandler_ParseSessionId(t *testing.T) {
 func TestHandler_SessionByRequest(t *testing.T) {
 	h := NewHandler("", testOptions, nil)
 	h.options.DisconnectDelay = 10 * time.Millisecond
-	var handlerFuncCalled = make(chan *session)
-	h.handlerFunc = func(s *session) { handlerFuncCalled <- s }
+	var handlerFuncCalled = make(chan Session)
+	h.handlerFunc = func(s Session) { handlerFuncCalled <- s }
 	req, _ := http.NewRequest("POST", "/server/sessionid/whatever/follows", nil)
 	sess, err := h.sessionByRequest(req)
 	if sess == nil || err != nil {
@@ -97,7 +97,7 @@ func TestHandler_SessionByRequest(t *testing.T) {
 		// test handlerFunc was called
 		select {
 		case s := <-handlerFuncCalled: // ok
-			if s != sess {
+			if s.session != sess {
 				t.Errorf("Handler was not passed correct session")
 			}
 		case <-time.After(100 * time.Millisecond):

--- a/v3/sockjs/htmlfile.go
+++ b/v3/sockjs/htmlfile.go
@@ -61,7 +61,7 @@ func (h *Handler) htmlFile(rw http.ResponseWriter, req *http.Request) {
 		recv.close()
 		return
 	}
-	sess.startHandlerOnce.Do(func() { go h.handlerFunc(sess) })
+	sess.startHandlerOnce.Do(func() { go h.handlerFunc(Session{sess}) })
 	select {
 	case <-recv.doneNotify():
 	case <-recv.interruptedNotify():

--- a/v3/sockjs/jsonp.go
+++ b/v3/sockjs/jsonp.go
@@ -40,7 +40,7 @@ func (h *Handler) jsonp(rw http.ResponseWriter, req *http.Request) {
 		recv.close()
 		return
 	}
-	sess.startHandlerOnce.Do(func() { go h.handlerFunc(sess) })
+	sess.startHandlerOnce.Do(func() { go h.handlerFunc(Session{sess}) })
 	select {
 	case <-recv.doneNotify():
 	case <-recv.interruptedNotify():

--- a/v3/sockjs/rawwebsocket.go
+++ b/v3/sockjs/rawwebsocket.go
@@ -28,7 +28,7 @@ func (h *Handler) rawWebsocket(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if h.handlerFunc != nil {
-		go h.handlerFunc(sess)
+		go h.handlerFunc(Session{sess})
 	}
 	readCloseCh := make(chan struct{})
 	go func() {

--- a/v3/sockjs/rawwebsocket_test.go
+++ b/v3/sockjs/rawwebsocket_test.go
@@ -26,8 +26,8 @@ func TestHandler_RawWebSocket(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.rawWebsocket))
 	defer server.CloseClientConnections()
 	url := "ws" + server.URL[4:]
-	var connCh = make(chan *session)
-	h.handlerFunc = func(conn *session) { connCh <- conn }
+	var connCh = make(chan Session)
+	h.handlerFunc = func(conn Session) { connCh <- conn }
 	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
 	if conn == nil {
 		t.Errorf("Connection should not be nil")
@@ -50,7 +50,7 @@ func TestHandler_RawWebSocketTerminationByServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.rawWebsocket))
 	defer server.Close()
 	url := "ws" + server.URL[4:]
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		// close the session without sending any message
 		if rt := conn.ReceiverType(); rt != ReceiverTypeRawWebsocket {
 			t.Errorf("Unexpected recevier type, got '%v', extected '%v'", rt, ReceiverTypeRawWebsocket)
@@ -83,7 +83,7 @@ func TestHandler_RawWebSocketTerminationByClient(t *testing.T) {
 	defer server.Close()
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		if _, err := conn.Recv(); err != ErrSessionNotOpen {
 			t.Errorf("Recv should fail")
 		}
@@ -101,7 +101,7 @@ func TestHandler_RawWebSocketCommunication(t *testing.T) {
 	// defer server.CloseClientConnections()
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		_ = conn.Send("message 1")
 		_ = conn.Send("message 2")
 		expected := "[\"message 3\"]\n"
@@ -136,7 +136,7 @@ func TestHandler_RawCustomWebSocketCommunication(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.rawWebsocket))
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		_ = conn.Send("message 1")
 		_ = conn.Send("message 2")
 		expected := "[\"message 3\"]\n"

--- a/v3/sockjs/session.go
+++ b/v3/sockjs/session.go
@@ -30,7 +30,9 @@ var (
 	errSessionParse            = errors.New("sockjs: unable to parse URL for session")
 )
 
-type Session = *session
+type Session struct {
+	*session
+}
 
 type session struct {
 	mux   sync.RWMutex

--- a/v3/sockjs/websocket.go
+++ b/v3/sockjs/websocket.go
@@ -26,7 +26,7 @@ func (h *Handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if h.handlerFunc != nil {
-		go h.handlerFunc(sess)
+		go h.handlerFunc(Session{sess})
 	}
 	readCloseCh := make(chan struct{})
 	go func() {

--- a/v3/sockjs/websocket_test.go
+++ b/v3/sockjs/websocket_test.go
@@ -35,8 +35,8 @@ func TestHandler_WebSocket(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
 	defer server.CloseClientConnections()
 	url := "ws" + server.URL[4:]
-	var connCh = make(chan *session)
-	h.handlerFunc = func(conn *session) {
+	var connCh = make(chan Session)
+	h.handlerFunc = func(conn Session) {
 		if rt := conn.ReceiverType(); rt != ReceiverTypeWebsocket {
 			t.Errorf("Unexpected recevier type, got '%v', extected '%v'", rt, ReceiverTypeWebsocket)
 		}
@@ -70,7 +70,7 @@ func TestHandler_WebSocketTerminationByServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
 	defer server.Close()
 	url := "ws" + server.URL[4:]
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		conn.Close(1024, "some close message")
 		conn.Close(0, "this should be ignored")
 	}
@@ -106,7 +106,7 @@ func TestHandler_WebSocketTerminationByClient(t *testing.T) {
 	defer server.Close()
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		if _, err := conn.Recv(); err != ErrSessionNotOpen {
 			t.Errorf("Recv should fail")
 		}
@@ -128,7 +128,7 @@ func TestHandler_WebSocketCommunication(t *testing.T) {
 	// defer server.CloseClientConnections()
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		noError(t, conn.Send("message 1"))
 		noError(t, conn.Send("message 2"))
 		msg, err := conn.Recv()
@@ -162,7 +162,7 @@ func TestHandler_CustomWebSocketCommunication(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
 	url := "ws" + server.URL[4:]
 	var done = make(chan struct{})
-	h.handlerFunc = func(conn *session) {
+	h.handlerFunc = func(conn Session) {
 		noError(t, conn.Send("message 1"))
 		noError(t, conn.Send("message 2"))
 		msg, err := conn.Recv()

--- a/v3/sockjs/xhr.go
+++ b/v3/sockjs/xhr.go
@@ -73,7 +73,7 @@ func (h *Handler) xhrPoll(rw http.ResponseWriter, req *http.Request) {
 
 	sess.startHandlerOnce.Do(func() {
 		if h.handlerFunc != nil {
-			go h.handlerFunc(sess)
+			go h.handlerFunc(Session{sess})
 		}
 	})
 
@@ -103,7 +103,7 @@ func (h *Handler) xhrStreaming(rw http.ResponseWriter, req *http.Request) {
 		receiver.close()
 		return
 	}
-	sess.startHandlerOnce.Do(func() { go h.handlerFunc(sess) })
+	sess.startHandlerOnce.Do(func() { go h.handlerFunc(Session{sess}) })
 
 	select {
 	case <-receiver.doneNotify():

--- a/v3/sockjs/xhr_test.go
+++ b/v3/sockjs/xhr_test.go
@@ -185,6 +185,6 @@ func newTestHandler() *Handler {
 	h := &Handler{sessions: make(map[string]*session)}
 	h.options.HeartbeatDelay = time.Hour
 	h.options.DisconnectDelay = time.Hour
-	h.handlerFunc = func(s *session) {}
+	h.handlerFunc = func(s Session) {}
 	return h
 }


### PR DESCRIPTION
As an attempt in `v3` to get rid of `Session` interface by aliasing it to `*session`, the problem shows up in go doc as the documentation misses functions for the `Session`: https://pkg.go.dev/github.com/igm/sockjs-go/v3/sockjs?tab=doc

This change embeds `*session` into `Session` struct and thus helping godoc.