### PR TITLE
eventsource escapes as done in sockjs-node

### DIFF
--- a/v3/sockjs/eventsource.go
+++ b/v3/sockjs/eventsource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 func (h *Handler) eventSource(rw http.ResponseWriter, req *http.Request) {
@@ -34,6 +36,13 @@ func (h *Handler) eventSource(rw http.ResponseWriter, req *http.Request) {
 
 type eventSourceFrameWriter struct{}
 
+var escaper *strings.Replacer = strings.NewReplacer(
+	"%", url.QueryEscape("%"),
+	"\n", url.QueryEscape("\n"),
+	"\r", url.QueryEscape("\r"),
+	"\x00", url.QueryEscape("\x00"),
+)
+
 func (*eventSourceFrameWriter) write(w io.Writer, frame string) (int, error) {
-	return fmt.Fprintf(w, "data: %s\r\n\r\n", frame)
+	return fmt.Fprintf(w, "data: %s\r\n\r\n", escaper.Replace(frame))
 }


### PR DESCRIPTION
change to address #100 for v3.

See also https://github.com/igm/sockjs-go/pull/101 for v2 changes.

Did not modify the root sockjs/eventsource.go.