### PR TITLE
Avoid a session wide deadlock for xhr transports

### DIFF
--- a/v3/sockjs/xhr.go
+++ b/v3/sockjs/xhr.go
@@ -35,17 +35,18 @@ func (h *Handler) xhrSend(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	h.sessionsMux.Lock()
-	defer h.sessionsMux.Unlock()
-	if sess, ok := h.sessions[sessionID]; !ok {
+	sess, ok := h.sessions[sessionID]
+	h.sessionsMux.Unlock()
+	if !ok {
 		http.NotFound(rw, req)
-	} else {
-		if err := sess.accept(messages...); err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		rw.Header().Set("content-type", "text/plain; charset=UTF-8") // Ignored by net/http (but protocol test complains), see https://code.google.com/p/go/source/detail?r=902dc062bff8
-		rw.WriteHeader(http.StatusNoContent)
+		return
 	}
+	if err := sess.accept(messages...); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rw.Header().Set("content-type", "text/plain; charset=UTF-8") // Ignored by net/http (but protocol test complains), see https://code.google.com/p/go/source/detail?r=902dc062bff8
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 type xhrFrameWriter struct{}


### PR DESCRIPTION
We had an issue in a project where one rogue session was causing failures in otherwise healthy sessions. i.e. rejection of a connection that our application code considered to be in error (it had failed an auth check) was causing all other healthy sessions to block and timeout.

To manifest it required 3 conditions:
- xhr poll/send transport being used
- application code _not_ calling `Close()` on the rogue session
- client side sending messages after the session receive handler had been shutdown.

I traced this to the global `sessionsMux` being used in `xhrSend()`. It is used to protect the sessions map, but is held longer than necessary - importantly it is held while ingesting the incoming messages. In order to ingest the incoming messages there must be a receiver in the application code to take them out of the buffer, otherwise the `sess.accept(messages...)` just blocks. (Unless of course `Close()` has been called which allows accept to proceed and the session to be tidied away).

So in the absence of a `Close()` call, `sess.accept()` blocks, the `sessionsMux` is still locked, and all other incoming xhrSend or xhr poll requests will block trying to lock the same mutex. Eventually leading to DisconnectDelay timing out and killing all sessions.

I appreciate our application code was faulty and should have been calling `Close()` on the rogue session, but the broader point about holding the lock longer than necessary still stands imho. It would only take a slow message receiver for one session to affect performance of all other sessions.

So, cutting to the chase, this PR changes `xhrSend()` so that this mutex is only held while extracting the session from the map. The mutex is unlocked immediately after and `sess.accept()` is run outside of the lock.
