### PR TITLE
Pass upgrader into options over interface

### DIFF
--- a/v3/sockjs/options.go
+++ b/v3/sockjs/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	RawWebsocket bool
 	// Provide a custom Upgrader for Websocket connections to enable features like compression.
 	// See https://godoc.org/github.com/gorilla/websocket#Upgrader for more details.
-	WebsocketUpgrader *websocket.Upgrader
+	WebsocketUpgrader upgrader
 	// WebsocketWriteTimeout is a custom write timeout for Websocket underlying network connection.
 	// A zero value means writes will not time out.
 	WebsocketWriteTimeout time.Duration
@@ -135,4 +135,8 @@ func generateEntropy() int32 {
 	entropy := entropy.Int31()
 	entropyMutex.Unlock()
 	return entropy
+}
+
+type upgrader interface {
+	Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*websocket.Conn, error)
 }


### PR DESCRIPTION
Hi!

I want to add custom header to websocket upgrade, but due to https://github.com/igm/sockjs-go/blob/master/v3/sockjs/websocket.go#L17 it can't be solved. So pass upgrader over interface is the simplest way to do it, and it changes allows to make another customizations on library users side.